### PR TITLE
[FIX] fixerio should look up currencies via config

### DIFF
--- a/test/data/settlementOneToOne.json
+++ b/test/data/settlementOneToOne.json
@@ -24,11 +24,11 @@
     "id": "http://usd-ledger.example/USD/transfers/4e1362c5-f4ef-466d-81ad-85d42c38a5e3",
     "ledger":"http://usd-ledger.example/USD",
     "debits": [{
-      "amount": ".00010592",
+      "amount": ".00010614",
       "account": "http://usd-ledger.example/accounts/alice"
     }],
     "credits": [{
-      "amount": ".00010592",
+      "amount": ".00010614",
       "account": "http://usd-ledger.example/accounts/mark"
     }],
     "state": "executed"

--- a/test/quoteSpec.js
+++ b/test/quoteSpec.js
@@ -127,7 +127,7 @@ describe('Quotes', function () {
             ledger: 'http://eur-ledger.example/EUR',
             credits: [{
               account: 'http://eur-ledger.example/accounts/mark',
-              amount: '94.22' // (1/ EUR/USD Rate of 1.0592) + .2% spread
+              amount: '94.60' // (1/ EUR/USD Rate of 1.0592) + .2% spread
             }],
             expiry_duration: '11'
           }],


### PR DESCRIPTION
Don't try to parse the ledger URI for a currency, just check the trading pairs
in the config.

Also use `subtractSpread` instead of `addSpread` when getting a quote
with a fixed destination amount.

/cc @emschwartz 
