### PR TITLE
Don't expect fulfillment in transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "five-bells-shared": "~9.0.1",
+    "five-bells-shared": "~9.2.0",
     "bignumber.js": "^2.0.7",
     "co": "^4.1.0",
     "co-body": "^4.0.0",

--- a/src/backends/fixerio/index.js
+++ b/src/backends/fixerio/index.js
@@ -117,7 +117,7 @@ class FixerIoBackend {
     const currencyPair = lookupCurrencies(params.source_ledger, params.destination_ledger)
     const destinationRate = this.rates[currencyPair[1]]
     const sourceRate = this.rates[currencyPair[0]]
-    let rate = new BigNumber(destinationRate).div(sourceRate).toFixed(5)
+    let rate = new BigNumber(destinationRate).div(sourceRate)
     // The spread is subtracted from the rate when going in either direction,
     // so that the DestinationAmount always ends up being slightly less than
     // the (equivalent) SourceAmount -- regardless of which of the 2 is fixed:

--- a/src/controllers/notifications.js
+++ b/src/controllers/notifications.js
@@ -2,6 +2,7 @@
 
 const requestUtil = require('five-bells-shared/utils/request')
 const Payments = require('../services/payments')
+const log = require('../services/log')('notifications')
 
 /* eslint-disable */
 /**
@@ -36,12 +37,14 @@ const Payments = require('../services/payments')
  *           "type": "ed25519-sha512",
  *           "public_key": "Lvf3YtnHLMER+VHT0aaeEJF+7WQcvp4iKZAdvMVto7c="
  *         },
+ *         "state": "executed"
+ *       },
+ *      "related_resources": {
  *         "execution_condition_fulfillment": {
  *           "type": "ed25519-sha512",
  *           "signature": "g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPCOzycOMpqHjg68+UmKPMYNQOq6Fov61IByzWhAA=="
  *         },
- *         "state": "executed"
- *       }
+ *      }
  *     }'
  *   https://connector.example/notifications
  *
@@ -53,8 +56,10 @@ const Payments = require('../services/payments')
 exports.post = function * postNotification () {
   let notification = yield requestUtil.validateBody(this, 'Notification')
 
+  log.debug('Got notification: ' + JSON.stringify(notification))
+
   if (notification.event === 'transfer.update') {
-    yield Payments.updateTransfer(notification.resource)
+    yield Payments.updateTransfer(notification.resource, notification.related_resources)
   }
 
   this.status = 200

--- a/src/lib/executeSourceTransfers.js
+++ b/src/lib/executeSourceTransfers.js
@@ -1,76 +1,36 @@
 'use strict'
 
-const _ = require('lodash')
 const ledgers = require('../services/ledgers')
 const log = require('../services/log')('executeSourceTransfers')
-const ExternalError = require('../errors/external-error')
-
-function * addConditionFulfillments (source_transfers, destination_transfers) {
-  for (let sourceTransfer of source_transfers) {
-    // Check if the source transfer's execution_condition is
-    // the execution of the destination transfer
-    let conditionsAreEqual = _.every(destination_transfers,
-      function (destinationTransfer) {
-        return _.isEqual(sourceTransfer.execution_condition,
-          destinationTransfer.execution_condition)
-      })
-
-    if (conditionsAreEqual) {
-      let transferWithConditionFulfillment = _.find(destination_transfers, (transfer) => {
-        return transfer.execution_condition_fulfillment
-      })
-
-      if (transferWithConditionFulfillment) {
-        sourceTransfer.execution_condition_fulfillment =
-          transferWithConditionFulfillment.execution_condition_fulfillment
-      } else {
-        log.warn('attempting to add execution_condition_fulfillment to source transfers ' +
-          'but none of the destination transfers have execution_condition_fulfillments')
-      }
-    } else {
-      // we know there is only one destination transfer
-
-      log.debug('checking destination transfer state')
-
-      let destinationTransferStateReq = yield ledgers.getState(
-        destination_transfers[0])
-
-      // TODO: add retry logic
-      if (destinationTransferStateReq.statusCode >= 400) {
-        log.error('remote error while checking destination transfer state')
-        throw new ExternalError('Received an unexpected ' +
-          destinationTransferStateReq.body.id +
-          ' while checking destination transfer state ' +
-          destination_transfers[0].id)
-      }
-
-      // TODO: validate that this actually comes back in the right format
-
-      if (destinationTransferStateReq.body.message &&
-        destinationTransferStateReq.body.message.state !== 'executed') {
-        log.warn('destination transfer not yet executed')
-      } else {
-        sourceTransfer.execution_condition_fulfillment = {
-          type: destinationTransferStateReq.body.type,
-          signature: destinationTransferStateReq.body.signature
-        }
-      }
-    }
-  }
-}
 
 // Add the execution_condition_fulfillment to the source transfer
 // and submit it to the source ledger
-function * executeSourceTransfers (source_transfers, destination_transfers) {
-  yield addConditionFulfillments(source_transfers, destination_transfers)
+function * executeSourceTransfers (sourceTransfers, destinationTransfers, relatedResources) {
+  let conditionFulfillment
+  if (relatedResources && relatedResources.execution_condition_fulfillment) {
+    conditionFulfillment = relatedResources.execution_condition_fulfillment
+  }
 
-  for (let sourceTransfer of source_transfers) {
-    log.debug('requesting fulfillment of source transfer')
-    const transferFulfillment = sourceTransfer.execution_condition_fulfillment
-    if (transferFulfillment) {
-      yield ledgers.putTransferFulfillment(sourceTransfer, transferFulfillment)
+  // This is a feature that will likely be deprecated.
+  // Right now we can use the last ledger's transfer state receipt as the execution_condition_fulfillment
+  if (!conditionFulfillment) {
+    const stateReceipt = yield ledgers.getState(destinationTransfers[0])
+    if (stateReceipt.type && stateReceipt.signature) {
+      conditionFulfillment = {
+        type: stateReceipt.type,
+        signature: stateReceipt.signature
+      }
+    } else {
+      log.error('Got invalid state receipt: ' + JSON.stringify(stateReceipt))
     }
+  }
 
+  for (let sourceTransfer of sourceTransfers) {
+    log.debug('Requesting fulfillment of source transfer: ' + sourceTransfer.id + ' (fulfillment: ' + JSON.stringify(conditionFulfillment) + ')')
+    // TODO check the timestamp on the response from the ledger against
+    // the transfer's expiry date
+    // See https://github.com/interledger/five-bells-ledger/issues/149
+    yield ledgers.putTransferFulfillment(sourceTransfer, conditionFulfillment)
     if (sourceTransfer.state !== 'executed') {
       log.error('Attempted to execute source transfer but it was unsucessful')
       log.debug(sourceTransfer)

--- a/src/lib/executeSourceTransfers.js
+++ b/src/lib/executeSourceTransfers.js
@@ -1,28 +1,61 @@
 'use strict'
 
+const _ = require('lodash')
 const ledgers = require('../services/ledgers')
 const log = require('../services/log')('executeSourceTransfers')
 
-// Add the execution_condition_fulfillment to the source transfer
-// and submit it to the source ledger
-function * executeSourceTransfers (sourceTransfers, destinationTransfers, relatedResources) {
-  let conditionFulfillment
+function * getConditionFulfillment (destinationTransfers, relatedResources) {
+  // There are 3 possible places we can get the fulfillment from:
+  // 1) If this function was triggered by an incoming notification of an executed
+  // payment it should include the fulfillment and that will be passed in as relatedResources
   if (relatedResources && relatedResources.execution_condition_fulfillment) {
-    conditionFulfillment = relatedResources.execution_condition_fulfillment
+    return relatedResources.execution_condition_fulfillment
   }
 
-  // This is a feature that will likely be deprecated.
-  // Right now we can use the last ledger's transfer state receipt as the execution_condition_fulfillment
-  if (!conditionFulfillment) {
+  // 2) If any of the destination transfers were executed as soon as we authorized
+  // them (e.g. if the fulfillment was somehow already there) or if the notification
+  // didn't come with the fulfillment for any reason we should request the fulfillment from the ledgers
+  const executedTransfers = _.filter(destinationTransfers, function (transfer) {
+    return transfer.state === 'executed' && transfer.execution_condition
+  })
+  let fulfillment
+  for (let transfer of executedTransfers) {
+    const transferFulfillment = yield ledgers.getTransferFulfillment(transfer)
+    // TODO do we need to check if this fulfills the specific source transfers we're
+    // interested in or should we assume that we'll ensure all the conditions are the
+    // same when we agree to facilitate a payment?
+    if (transferFulfillment) {
+      fulfillment = transferFulfillment
+      break
+    }
+  }
+  if (fulfillment) {
+    return fulfillment
+  }
+
+  // 3) Right now we can use the last ledger's transfer state receipt as the execution_condition_fulfillment
+  // Note that this is a feature that will likely be deprecated
+  if (destinationTransfers.length === 1) {
     const stateReceipt = yield ledgers.getState(destinationTransfers[0])
     if (stateReceipt.type && stateReceipt.signature) {
-      conditionFulfillment = {
+      return {
         type: stateReceipt.type,
         signature: stateReceipt.signature
       }
     } else {
       log.error('Got invalid state receipt: ' + JSON.stringify(stateReceipt))
     }
+  }
+}
+
+// Add the execution_condition_fulfillment to the source transfer
+// and submit it to the source ledger
+function * executeSourceTransfers (sourceTransfers, destinationTransfers, relatedResources) {
+  const conditionFulfillment = yield getConditionFulfillment(destinationTransfers, relatedResources)
+
+  if (!conditionFulfillment) {
+    log.error('Cannot execute source transfers, no condition fulfillment found. Destination transfers: ' + JSON.stringify(destinationTransfers))
+    return
   }
 
   for (let sourceTransfer of sourceTransfers) {

--- a/src/lib/ledgers/five-bells-ledger.js
+++ b/src/lib/ledgers/five-bells-ledger.js
@@ -64,6 +64,14 @@ FiveBellsLedger.prototype.putTransferFulfillment = function * (transfer, executi
   return fulfillmentRes.body
 }
 
+FiveBellsLedger.prototype.getTransferFulfillment = function * (transfer) {
+  const fulfillmentRes = yield this._request({
+    method: 'get',
+    uri: transfer.id + '/fulfillment'
+  })
+  return fulfillmentRes.body
+}
+
 FiveBellsLedger.prototype._request = function * (opts) {
   // TODO: check before this point that we actually have
   // credentials for the ledgers we're asked to settle between

--- a/src/lib/ledgers/five-bells-ledger.js
+++ b/src/lib/ledgers/five-bells-ledger.js
@@ -29,30 +29,39 @@ FiveBellsLedger.prototype.makeFundTemplate = function (template) {
   return template
 }
 
-FiveBellsLedger.prototype.getState = function (transfer) {
-  return request({
+FiveBellsLedger.prototype.getState = function * (transfer) {
+  const stateRes = yield this._request({
     method: 'get',
     uri: transfer.id + '/state',
     json: true
   })
+  return stateRes.body
 }
 
 FiveBellsLedger.prototype.putTransfer = function * (transfer) {
-  const updatedTransfer = yield this._request({
+  const transferRes = yield this._request({
     method: 'put',
     uri: transfer.id,
     body: transfer
   })
+  const updatedTransfer = transferRes.body
   updateTransfer(transfer, updatedTransfer)
 }
 
 FiveBellsLedger.prototype.putTransferFulfillment = function * (transfer, execution_condition_fulfillment) {
-  const updatedTransfer = yield this._request({
+  const fulfillmentRes = yield this._request({
     method: 'put',
     uri: transfer.id + '/fulfillment',
     body: execution_condition_fulfillment
   })
-  updateTransfer(transfer, updatedTransfer)
+  // TODO check the timestamp the ledger sends back
+  // See https://github.com/interledger/five-bells-ledger/issues/149
+  if (fulfillmentRes.statusCode === 200 || fulfillmentRes.statusCode === 201) {
+    transfer.state = 'executed'
+  } else {
+    log.error('Failed to submit fulfillment for transfer: ' + transfer.id + ' Error: ' + (fulfillmentRes.body ? JSON.stringify(fulfillmentRes.body) : fulfillmentRes.error))
+  }
+  return fulfillmentRes.body
 }
 
 FiveBellsLedger.prototype._request = function * (opts) {
@@ -70,7 +79,7 @@ FiveBellsLedger.prototype._request = function * (opts) {
   if (transferRes.statusCode >= 400) {
     throw new ExternalError('Remote error: status=' + transferRes.statusCode + ' body=' + transferRes.body)
   }
-  return transferRes.body
+  return transferRes
 }
 
 // Update destination_transfer state from the ledger's response

--- a/src/lib/ledgers/multiledger.js
+++ b/src/lib/ledgers/multiledger.js
@@ -69,6 +69,10 @@ Multiledger.prototype.putTransferFulfillment = function (transfer, fulfillment) 
   return this.getLedger(transfer.ledger).putTransferFulfillment(transfer, fulfillment)
 }
 
+Multiledger.prototype.getTransferFulfillment = function (transfer) {
+  return this.getLedger(transfer.ledger).getTransferFulfillment(transfer)
+}
+
 // target - {uri, transfer}
 Multiledger.prototype.subscribe = function (ledger_id, target) {
   let ledger = this.getLedger(ledger_id)

--- a/src/services/destinationSubscriptions.js
+++ b/src/services/destinationSubscriptions.js
@@ -1,9 +1,13 @@
 'use strict'
 
+const _ = require('lodash')
+const log = require('./log')('destinationSubscriptions')
+
 const records = {}
 
-exports.put = function (destinationTransferId, sourceTransfer) {
-  records[destinationTransferId] = sourceTransfer
+exports.put = function (destinationTransferId, sourceTransfers) {
+  records[destinationTransferId] = sourceTransfers
+  log.debug('put subscription record: ' + destinationTransferId + ' -> ' + _.map(sourceTransfers, 'id'))
 }
 
 exports.get = function (destinationTransferId) {

--- a/test/data/notificationWithConditionFulfillment.json
+++ b/test/data/notificationWithConditionFulfillment.json
@@ -18,10 +18,12 @@
       "type": "ed25519-sha512",
       "public_key": "Lvf3YtnHLMER+VHT0aaeEJF+7WQcvp4iKZAdvMVto7c="
     },
+    "state": "executed"
+  },
+  "related_resources": {
     "execution_condition_fulfillment": {
       "type": "ed25519-sha512",
       "signature": "sd0RahwuJJgeNfg8HvWHtYf4uqNgCOqIbseERacqs8G0kXNQQnhfV6gWAnMb+0RIlY3e0mqbrQiUwbRYJvRBAw=="
-    },
-    "state": "executed"
+    }
   }
 }

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -44,6 +44,10 @@ describe('Notifications', function () {
     })
 
     afterEach(function * () {
+      if (nock.pendingMocks() && nock.pendingMocks().length) {
+        console.log('Pending mocks: ', nock.pendingMocks())
+        throw new Error('Pending mocks')
+      }
       nock.cleanAll()
       this.clock.restore()
     })
@@ -152,17 +156,8 @@ describe('Notifications', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('', _.assign({}, payment.source_transfers[0], {
-          execution_condition_fulfillment: this.notificationWithConditionFulfillment
-            .resource.execution_condition_fulfillment
-        }))
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
-
-      nock(this.notificationWithConditionFulfillment.id)
-        .delete('')
-        .reply(200)
+        .put('/fulfillment', this.notificationWithConditionFulfillment.related_resources.execution_condition_fulfillment)
+        .reply(201, this.notificationWithConditionFulfillment.related_resources.execution_condition_fulfillment)
 
       yield this.request()
         .put('/payments/' + this.paymentSameExecutionCondition.id)
@@ -201,10 +196,6 @@ describe('Notifications', function () {
           state: 'executed'
         }))
 
-      nock(this.notificationNoConditionFulfillment.id)
-        .delete('')
-        .reply(200)
-
       yield this.request()
         .put('/payments/' + this.paymentOneToOne.id)
         .send(payment)
@@ -238,10 +229,6 @@ describe('Notifications', function () {
         .reply(201, _.assign({}, payment.source_transfers[0], {
           state: 'executed'
         }))
-
-      nock(this.notificationWithConditionFulfillment.id)
-        .delete('')
-        .reply(200)
 
       yield this.request()
         .put('/payments/' + this.paymentSameExecutionCondition.id)
@@ -284,10 +271,6 @@ describe('Notifications', function () {
           state: 'executed'
         }))
 
-      nock(this.notificationWithConditionFulfillment.id)
-        .delete('')
-        .reply(200)
-
       yield this.request()
         .put('/payments/' + this.paymentManyToOne.id)
         .send(payment)
@@ -320,8 +303,6 @@ describe('Notifications', function () {
 
         nock(payment.destination_transfers[0].id)
           .get('/state')
-          .reply(200, this.transferProposedReceipt)
-          .get('/state')
           .reply(200, this.transferExecutedReceipt)
 
         let firstSourceTransferExecuted = nock(payment.source_transfers[0].id)
@@ -339,10 +320,6 @@ describe('Notifications', function () {
           .reply(201, _.assign({}, payment.source_transfers[1], {
             state: 'executed'
           }))
-
-        nock(this.notificationWithConditionFulfillment.id)
-          .delete('')
-          .reply(200)
 
         yield this.request()
           .put('/payments/' + this.paymentManyToOne.id)

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -218,7 +218,7 @@ describe('Notifications', function () {
         .end()
 
       // Throw an error if this nock hasn't been executed
-      sourceTransferExecuted.isDone()
+      sourceTransferExecuted.done()
     })
 
     it('should submit the source transfer corresponding to the destination transfer it is notified about if the execution conditions are the same', function *() {
@@ -256,7 +256,7 @@ describe('Notifications', function () {
         .end()
 
       // Throw an error if this nock hasn't been executed
-      sourceTransferExecuted.isDone()
+      sourceTransferExecuted.done()
     })
 
     it('should submit multiple source transfers if there are multiple that correspond to a single destination transfer it is notified about', function *() {
@@ -301,8 +301,8 @@ describe('Notifications', function () {
         .end()
 
       // Throw an error if this nock hasn't been executed
-      firstSourceTransferExecuted.isDone()
-      secondSourceTransferExecuted.isDone()
+      firstSourceTransferExecuted.done()
+      secondSourceTransferExecuted.done()
     })
 
     it('should submit multiple source transfers with the right execution conditions even if one has the same condition as the destination transfer and another\'s condition is the destination transfer itself',
@@ -357,46 +357,8 @@ describe('Notifications', function () {
           .end()
 
         // Throw an error if this nock hasn't been executed
-        firstSourceTransferExecuted.isDone()
-        secondSourceTransferExecuted.isDone()
+        firstSourceTransferExecuted.done()
+        secondSourceTransferExecuted.done()
       })
-
-    it('should delete the subscription once it has submitted the source transfers', function *() {
-      const payment = this.formatId(this.paymentSameExecutionCondition,
-        '/payments/')
-
-      nock(payment.destination_transfers[0].id)
-        .put('')
-        .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'prepared'
-        }))
-
-      nock(payment.source_transfers[0].id)
-        .put('/fulfillment',
-          this.notificationWithConditionFulfillment
-            .resource.execution_condition_fulfillment)
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
-
-      let subscriptionDeleted = nock(this.notificationWithConditionFulfillment.id)
-        .delete('')
-        .reply(200)
-
-      yield this.request()
-        .put('/payments/' + this.paymentSameExecutionCondition.id)
-        .send(payment)
-        .expect(201)
-        .end()
-
-      yield this.request()
-        .post('/notifications')
-        .send(this.notificationWithConditionFulfillment)
-        .expect(200)
-        .end()
-
-      // Throw an error if this nock hasn't been executed
-      subscriptionDeleted.isDone()
-    })
   })
 })

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -44,10 +44,7 @@ describe('Notifications', function () {
     })
 
     afterEach(function * () {
-      if (nock.pendingMocks() && nock.pendingMocks().length) {
-        console.log('Pending mocks: ', nock.pendingMocks())
-        throw new Error('Pending mocks')
-      }
+      expect(nock.pendingMocks()).to.be.empty
       nock.cleanAll()
       this.clock.restore()
     })

--- a/test/paymentSpec.js
+++ b/test/paymentSpec.js
@@ -54,8 +54,7 @@ describe('Payments', function () {
 
   describe('PUT /payments/:id', function () {
     it('should return a 400 if the id is not a valid uuid', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.id = 'not valid'
 
       yield this.request()
@@ -89,8 +88,7 @@ describe('Payments', function () {
     })
 
     it('should return a 422 if the two transfer conditions do not match and the source transfer one does not have the public key of the destination ledger', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
 
       payment.source_transfers[0].execution_condition =
         _.assign({}, payment.source_transfers[0].execution_condition, {
@@ -118,8 +116,7 @@ describe('Payments', function () {
       'destination ledger uses')
 
     it('should return a 422 if the payment does not include the connector in the source transfer credits', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].credits[0].account = 'http://usd-ledger.example/accounts/mary'
 
       yield this.request()
@@ -135,8 +132,7 @@ describe('Payments', function () {
     })
 
     it('should return a 422 if the payment does not include the connector in the destination transfer debits', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.destination_transfers[0].debits[0].account = 'http://eur-ledger.example/accounts/mary'
 
       yield this.request()
@@ -152,8 +148,7 @@ describe('Payments', function () {
     })
 
     it('should return a 422 if the rate of the payment is worse than the one currently offered', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].credits[0].amount = '1.00'
 
       yield this.request()
@@ -207,8 +202,7 @@ describe('Payments', function () {
     })
 
     it('should return a 422 if the payment includes assets this connector does not offer rates between', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].ledger = 'http://abc-ledger.example/ABC'
       payment.destination_transfers[0].ledger =
         'http://xyz-ledger.example/XYZ'
@@ -226,8 +220,7 @@ describe('Payments', function () {
     })
 
     it('should return a 201 if the source_transfer is not in the prepared or executed state', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].state = 'proposed'
 
       nock(payment.destination_transfers[0].id)
@@ -336,8 +329,7 @@ describe('Payments', function () {
     })
 
     it('should return a 422 if the source transfer\'s execution condition is the execution of the destination transfer but the destination transfer expires too soon', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.destination_transfers[0].expires_at =
         moment(START_DATE + 999).toISOString()
 
@@ -354,8 +346,7 @@ describe('Payments', function () {
     })
 
     it('should return a 422 if the source transfer\'s execution condition is the execution of the destination transfer but the source transfer expires too soon (we may not be able to execute the source transfer in time)', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].expires_at =
         moment(START_DATE + 1999).toISOString()
 
@@ -374,8 +365,7 @@ describe('Payments', function () {
 
     it.skip('should return a 422 if the source transfer does not ' +
       'have source_fee_transfers', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       delete payment.source_fee_transfers
 
       yield this.request()
@@ -392,8 +382,7 @@ describe('Payments', function () {
 
     it.skip('should return a 422 if the source transfer rejection_credits ' +
       'do not cover the cost of holding funds', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_fee_transfers[0].credits[0].amount = '.000104'
 
       yield this.request()
@@ -411,11 +400,15 @@ describe('Payments', function () {
 
     it('should accept upper case UUIDs but convert them to lower case', function *() {
       this.paymentOneToOne.id = this.paymentOneToOne.id.toUpperCase()
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
 
       const connectorCredentials =
         config.ledgerCredentials[payment.destination_transfers[0].ledger]
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       nock(payment.destination_transfers[0].id)
         .put('')
@@ -428,10 +421,8 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
@@ -457,6 +448,11 @@ describe('Payments', function () {
       const connectorCredentials =
         config.ledgerCredentials[payment.destination_transfers[0].ledger]
 
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
+
       nock(payment.destination_transfers[0].id)
         .put('')
         .basicAuth({
@@ -468,10 +464,8 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
@@ -489,8 +483,7 @@ describe('Payments', function () {
     })
 
     it('should return a 201 for a new payment even if the connector is also the payee of the destination transfer', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.destination_transfers[0].credits =
         payment.destination_transfers[0].debits
 
@@ -507,11 +500,14 @@ describe('Payments', function () {
           state: 'executed'
         }))
 
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
+
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
@@ -529,13 +525,16 @@ describe('Payments', function () {
     })
 
     it('should return a 201 for a new payment even if the connector is also the payer of the source transfer', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].debits =
         payment.source_transfers[0].credits
 
-      const connectorCredentials =
-        config.ledgerCredentials[payment.destination_transfers[0].ledger]
+      const connectorCredentials = config.ledgerCredentials[payment.destination_transfers[0].ledger]
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       nock(payment.destination_transfers[0].id)
         .put('')
@@ -548,10 +547,8 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
@@ -573,8 +570,12 @@ describe('Payments', function () {
     // })
 
     it('should authorize the transfer on the destination ledger', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       // we're testing to make sure this nock gets called
       const destinationTransferNock =
@@ -593,14 +594,13 @@ describe('Payments', function () {
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
-        .times(2)
         .reply(200, this.transferProposedReceipt)
+        .get('/state')
+        .reply(200, this.transferExecutedReceipt)
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       yield this.request()
         .put('/payments/' + this.paymentOneToOne.id)
@@ -612,11 +612,15 @@ describe('Payments', function () {
     })
 
     it('should execute a payment where the source transfer condition is the destination transfer', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
 
       const connectorCredentials =
         config.ledgerCredentials[payment.destination_transfers[0].ledger]
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       nock(payment.destination_transfers[0].id)
         .put('')
@@ -629,16 +633,12 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferProposedReceipt)
-
-      nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferExecutedReceipt)
 
@@ -648,11 +648,7 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: {
-              type: 'ed25519-sha512',
-              signature: this.transferExecutedReceipt.signature
-            }
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
@@ -664,66 +660,22 @@ describe('Payments', function () {
         .end()
     })
 
-    it('should execute a payment where the source transfer condition is equal to the destination transfer condition', function *() {
-      // secret: zU/Q8UzeDi4gHeKAFus1sXDNJ+F7id2AdMR8NXhe1slnYVZLVcvPzA2lFFdxef3y0LrIiuCV8jzs6yYDclN8yA==
-      const fulfillment = {
-        type: 'ed25519-sha512',
-        signature: 'g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPCOzycOM' +
-          'pqHjg68+UmKPMYNQOq6Fov61IByzWhAA=='
-      }
+    it.skip('should add a subscription record for a payment where the source transfer condition is equal to the destination transfer condition and the destination transfer is not yet executed')
 
-      const payment = this.formatId(this.paymentSameExecutionCondition,
-        '/payments/')
-
-      const connectorCredentials =
-        config.ledgerCredentials[payment.destination_transfers[0].ledger]
-
-      nock(payment.destination_transfers[0].id)
-        .put('')
-        .basicAuth({
-          user: connectorCredentials.username,
-          pass: connectorCredentials.password
-        })
-        .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      nock(payment.source_transfers[0].id)
-        .put('/fulfillment', fulfillment)
-        .reply(201, _.merge(_.cloneDeep(payment.source_transfers[0]), {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      yield this.request()
-        .put('/payments/' + this.paymentOneToOne.id)
-        .send(payment)
-        .expect(201, _.merge(_.cloneDeep(payment), {
-          state: 'executed',
-          source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
-          }],
-          destination_transfers: [{
-            state: 'executed',
-            debits: [{
-              authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
-          }]
-        }))
-        .end()
-    })
+    it.skip('should add subscription records for a payment with one source transfer and multiple destination transfers')
 
     it('should execute a payment where its account is not the only credit in the source transfer', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].debits[0].amount = '21.07'
       payment.source_transfers[0].credits.unshift({
         account: 'http://usd-ledger.example/accounts/mary',
         amount: '20'
       })
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       const connectorCredentials =
       config.ledgerCredentials[payment.destination_transfers[0].ledger]
@@ -739,10 +691,8 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
@@ -758,11 +708,7 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: {
-              type: 'ed25519-sha512',
-              signature: this.transferExecutedReceipt.signature
-            }
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
@@ -778,13 +724,17 @@ describe('Payments', function () {
       // Note there is no good reason why this should happen but we should
       // be able to handle it appropriately anyway
 
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.destination_transfers[0].debits[0].amount = '0.60'
       payment.destination_transfers[0].debits.push({
         account: 'http://eur-ledger.example/accounts/mark',
         amount: '0.40'
       })
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       const connectorCredentials =
         config.ledgerCredentials[payment.destination_transfers[0].ledger]
@@ -800,10 +750,8 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
@@ -819,11 +767,7 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: {
-              type: 'ed25519-sha512',
-              signature: this.transferExecutedReceipt.signature
-            }
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
@@ -838,13 +782,17 @@ describe('Payments', function () {
     })
 
     it('should execute a payment where there are multiple credits in the destination transfer', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.destination_transfers[0].credits[0].amount = '0.60'
       payment.destination_transfers[0].credits.push({
         account: 'http://usd-ledger.example/accounts/timothy',
         amount: '0.40'
       })
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       const connectorCredentials =
         config.ledgerCredentials[payment.destination_transfers[0].ledger]
@@ -860,16 +808,12 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferProposedReceipt)
-
-      nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferExecutedReceipt)
 
@@ -879,11 +823,7 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: {
-              type: 'ed25519-sha512',
-              signature: this.transferExecutedReceipt.signature
-            }
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
@@ -896,8 +836,7 @@ describe('Payments', function () {
     })
 
     it('should only add authorization to the destination transfer debits from the connector\'s account', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.destination_transfers[0].debits.unshift({
         amount: '10',
         account: 'http://eur-ledger.example/accounts/other'
@@ -906,6 +845,11 @@ describe('Payments', function () {
         amount: '10',
         account: 'http://eur-ledger.example/accounts/jane'
       })
+
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
 
       const connectorCredentials =
       config.ledgerCredentials[payment.destination_transfers[0].ledger]
@@ -921,16 +865,12 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferProposedReceipt)
-
-      nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferExecutedReceipt)
 
@@ -940,11 +880,7 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: {
-              type: 'ed25519-sha512',
-              signature: this.transferExecutedReceipt.signature
-            }
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
@@ -961,88 +897,13 @@ describe('Payments', function () {
       submittedAuthorization.done()
     })
 
-    it('should execute a payment with one source transfer and multiple destination transfers', function *() {
-      const payment = this.formatId(this.paymentOneToMany,
-        '/payments/')
-
-      const fulfillment = {
-        type: 'ed25519-sha512',
-        signature: 'g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPC' +
-          'OzycOMpqHjg68+UmKPMYNQOq6Fov61IByzWhAA=='
-      }
-
-      const connectorCredentials0 =
-      config.ledgerCredentials[payment.destination_transfers[0].ledger]
-      const submittedAuthorization0 =
-      nock(payment.destination_transfers[0].id)
-        .put('')
-        .basicAuth({
-          user: connectorCredentials0.username,
-          pass: connectorCredentials0.password
-        })
-        .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      const connectorCredentials1 =
-      config.ledgerCredentials[payment.destination_transfers[1].ledger]
-      const submittedAuthorization1 =
-      nock(payment.destination_transfers[1].id)
-        .put('')
-        .basicAuth({
-          user: connectorCredentials1.username,
-          pass: connectorCredentials1.password
-        })
-        .reply(201, _.assign({}, payment.destination_transfers[1], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      yield this.request()
-        .put('/payments/' + this.paymentOneToOne.id)
-        .send(payment)
-        .expect(201, _.merge(_.cloneDeep(payment), {
-          state: 'executed',
-          source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
-          }],
-          destination_transfers: [{
-            state: 'executed',
-            debits: [{
-              authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
-          }, {
-            state: 'executed',
-            debits: [{
-              authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
-          }]
-        }))
-        .end()
-
-      submittedAuthorization0.done()
-      submittedAuthorization1.done()
-    })
-
     it('should execute a payment with multiple source transfers and one destination transfer', function *() {
       const payment = this.formatId(this.paymentManyToOne,
         '/payments/')
 
       const fulfillment = {
-        type: 'ed25519-sha512',
-        signature: 'g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPC' +
-          'OzycOMpqHjg68+UmKPMYNQOq6Fov61IByzWhAA=='
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
       }
 
       const connectorCredentials =
@@ -1055,23 +916,20 @@ describe('Payments', function () {
           pass: connectorCredentials.password
         })
         .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
+          state: 'executed'
         }))
+
+      nock(payment.destination_transfers[0].id)
+        .get('/state')
+        .reply(200, this.transferExecutedReceipt)
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.source_transfers[1].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       yield this.request()
         .put('/payments/' + this.paymentOneToOne.id)
@@ -1079,26 +937,22 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
+            state: 'executed'
           }, {
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
             debits: [{
               authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
+            }]
           }]
         }))
         .end()
     })
 
     it('should execute a payment where the source transfer\'s expires_at date has passed if the transfer was executed before it expired', function *() {
-      const payment = this.formatId(this.paymentOneToOne,
-        '/payments/')
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
       payment.source_transfers[0].expires_at =
         moment(START_DATE - 1).toISOString()
       payment.source_transfers[0].state = 'executed'
@@ -1106,6 +960,11 @@ describe('Payments', function () {
       const connectorCredentials =
         config.ledgerCredentials[payment.destination_transfers[0].ledger]
 
+      const fulfillment = {
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
+      }
+
       nock(payment.destination_transfers[0].id)
         .put('')
         .basicAuth({
@@ -1117,16 +976,12 @@ describe('Payments', function () {
         }))
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(200, _.assign({}, payment.source_transfers[0], {
-          state: 'executed'
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(200, fulfillment)
 
       nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferProposedReceipt)
-
-      nock(payment.destination_transfers[0].id)
         .get('/state')
         .reply(200, this.transferExecutedReceipt)
 
@@ -1134,142 +989,6 @@ describe('Payments', function () {
         .put('/payments/' + this.paymentOneToOne.id)
         .send(payment)
         .expect(201)
-        .end()
-    })
-
-    it('should execute a one-to-many payment where it is credited in both the source and destination transfers', function *() {
-      const payment = this.formatId(this.paymentOneToMany,
-        '/payments/')
-
-      payment.destination_transfers[1].credits[0].account = 'http://cny-ledger.example/accounts/mark'
-
-      const fulfillment = {
-        type: 'ed25519-sha512',
-        signature: 'g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPC' +
-          'OzycOMpqHjg68+UmKPMYNQOq6Fov61IByzWhAA=='
-      }
-
-      const connectorCredentials =
-        config.ledgerCredentials[payment.destination_transfers[0].ledger]
-
-      nock(payment.destination_transfers[0].id)
-        .put('')
-        .basicAuth({
-          user: connectorCredentials.username,
-          pass: connectorCredentials.password
-        })
-        .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      nock(payment.destination_transfers[1].id)
-        .put('')
-        .reply(201, _.assign({}, payment.destination_transfers[1], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      yield this.request()
-        .put('/payments/' + this.paymentOneToOne.id)
-        .send(payment)
-        .expect(201, _.merge(_.cloneDeep(payment), {
-          state: 'executed',
-          source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
-          }],
-          destination_transfers: [{
-            state: 'executed',
-            debits: [{
-              authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
-          }, {
-            state: 'executed',
-            debits: [{
-              authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
-          }]
-        }))
-        .end()
-    })
-
-    it('should execute a one-to-many payment where it is debited in both the source and destination transfers', function *() {
-      const payment = this.formatId(this.paymentOneToMany,
-        '/payments/')
-
-      payment.source_transfers[0].debits[0] = {
-        account: 'http://usd-ledger.example/accounts/mark',
-        amount: '10',
-        authorized: true
-      }
-
-      const fulfillment = {
-        type: 'ed25519-sha512',
-        signature: 'g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPC' +
-          'OzycOMpqHjg68+UmKPMYNQOq6Fov61IByzWhAA=='
-      }
-
-      const connectorCredentials =
-        config.ledgerCredentials[payment.destination_transfers[0].ledger]
-
-      nock(payment.destination_transfers[0].id)
-        .put('')
-        .basicAuth({
-          user: connectorCredentials.username,
-          pass: connectorCredentials.password
-        })
-        .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      nock(payment.destination_transfers[1].id)
-        .put('')
-        .reply(201, _.assign({}, payment.destination_transfers[1], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
-
-      yield this.request()
-        .put('/payments/' + this.paymentOneToOne.id)
-        .send(payment)
-        .expect(201, _.merge(_.cloneDeep(payment), {
-          state: 'executed',
-          source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
-          }],
-          destination_transfers: [{
-            state: 'executed',
-            debits: [{
-              authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
-          }, {
-            state: 'executed',
-            debits: [{
-              authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
-          }]
-        }))
         .end()
     })
 
@@ -1281,9 +1000,8 @@ describe('Payments', function () {
         'http://usd-ledger.example/accounts/mark'
 
       const fulfillment = {
-        type: 'ed25519-sha512',
-        signature: 'g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPC' +
-          'OzycOMpqHjg68+UmKPMYNQOq6Fov61IByzWhAA=='
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
       }
 
       const connectorCredentials =
@@ -1296,23 +1014,20 @@ describe('Payments', function () {
           pass: connectorCredentials.password
         })
         .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
+          state: 'executed'
         }))
+
+      nock(payment.destination_transfers[0].id)
+        .get('/state')
+        .reply(200, this.transferExecutedReceipt)
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.source_transfers[1].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       yield this.request()
         .put('/payments/' + this.paymentOneToOne.id)
@@ -1320,18 +1035,15 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
+            state: 'executed'
           }, {
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
             debits: [{
               authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
+            }]
           }]
         }))
         .end()
@@ -1348,9 +1060,8 @@ describe('Payments', function () {
       }
 
       const fulfillment = {
-        type: 'ed25519-sha512',
-        signature: 'g8fxfTqO4z7ohmqYARSqKFhIgBZt6KvxD2irrSHHhES9diPC' +
-          'OzycOMpqHjg68+UmKPMYNQOq6Fov61IByzWhAA=='
+        type: this.transferExecutedReceipt.type,
+        signature: this.transferExecutedReceipt.signature
       }
 
       const connectorCredentials =
@@ -1363,23 +1074,20 @@ describe('Payments', function () {
           pass: connectorCredentials.password
         })
         .reply(201, _.assign({}, payment.destination_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
+          state: 'executed'
         }))
+
+      nock(payment.destination_transfers[0].id)
+        .get('/state')
+        .reply(200, this.transferExecutedReceipt)
 
       nock(payment.source_transfers[0].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       nock(payment.source_transfers[1].id)
-        .put('/fulfillment')
-        .reply(201, _.assign({}, payment.source_transfers[0], {
-          state: 'executed',
-          execution_condition_fulfillment: fulfillment
-        }))
+        .put('/fulfillment', fulfillment)
+        .reply(201, fulfillment)
 
       yield this.request()
         .put('/payments/' + this.paymentOneToOne.id)
@@ -1387,18 +1095,15 @@ describe('Payments', function () {
         .expect(201, _.merge(_.cloneDeep(payment), {
           state: 'executed',
           source_transfers: [{
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
+            state: 'executed'
           }, {
-            state: 'executed',
-            execution_condition_fulfillment: fulfillment
+            state: 'executed'
           }],
           destination_transfers: [{
             state: 'executed',
             debits: [{
               authorized: true
-            }],
-            execution_condition_fulfillment: fulfillment
+            }]
           }]
         }))
         .end()

--- a/test/paymentSpec.js
+++ b/test/paymentSpec.js
@@ -48,6 +48,10 @@ describe('Payments', function () {
   })
 
   afterEach(function * () {
+    if (nock.pendingMocks() && nock.pendingMocks().length) {
+      console.log('Pending mocks: ', nock.pendingMocks())
+      throw new Error('Pending mocks')
+    }
     nock.cleanAll()
     this.clock.restore()
   })

--- a/test/paymentSpec.js
+++ b/test/paymentSpec.js
@@ -48,10 +48,7 @@ describe('Payments', function () {
   })
 
   afterEach(function * () {
-    if (nock.pendingMocks() && nock.pendingMocks().length) {
-      console.log('Pending mocks: ', nock.pendingMocks())
-      throw new Error('Pending mocks')
-    }
+    expect(nock.pendingMocks()).to.be.empty
     nock.cleanAll()
     this.clock.restore()
   })

--- a/test/quoteSpec.js
+++ b/test/quoteSpec.js
@@ -260,11 +260,11 @@ describe('Quotes', function () {
           destination_transfers: [{
             ledger: 'http://eur-ledger.example/EUR',
             debits: [{
-              amount: '94.2221', // 1 / (EUR/USD Rate of 1.0592 + .2% spread)
+              amount: '94.2220', // 1 / (EUR/USD Rate of 1.0592 + .2% spread)
               account: 'http://eur-ledger.example/accounts/mark'
             }],
             credits: [{
-              amount: '94.2221', // 1 / (EUR/USD Rate of 1.0592 + .2% spread)
+              amount: '94.2220', // 1 / (EUR/USD Rate of 1.0592 + .2% spread)
               account: null
             }],
             expiry_duration: '10'
@@ -294,11 +294,11 @@ describe('Quotes', function () {
           destination_transfers: [{
             ledger: 'http://cad-ledger.example/CAD',
             debits: [{
-              amount: '127.9815', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread
+              amount: '127.9818', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread
               account: 'http://cad-ledger.example/accounts/mark'
             }],
             credits: [{
-              amount: '127.9815', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread
+              amount: '127.9818', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread
               account: null
             }],
             expiry_duration: '10'
@@ -329,11 +329,11 @@ describe('Quotes', function () {
             ledger: 'http://usd-ledger.example/USD',
             debits: [{
               account: 'http://usd-ledger.example/accounts/mark',
-              amount: '77.8240' // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread)
+              amount: '77.8238' // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread)
             }],
             credits: [{
               account: null,
-              amount: '77.8240' // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread)
+              amount: '77.8238' // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread)
             }],
             expiry_duration: '10'
           }]


### PR DESCRIPTION
As of [five-bells-shared v9.2.0](https://github.com/interledger/five-bells-shared/commit/2ebbbbb5e15fd594a7ddd9eea4ffdd99e00f33e4) the `execution_condition_fulfillment` was moved from the transfer object to the notification. This updates the connector accordingly and fixes broken tests.
Fixes https://github.com/interledger/five-bells-connector/issues/79