### PR TITLE
FIX: Pass username into client-cert credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ npm start
   // Using Client Certificate Auth
   "<ledger_uri_2>": {
     "account_uri": "...",
+    "username": "...",
     "cert": "...",
     "key": "...",
     "ca": "...", // Optional

--- a/src/lib/ledgers/five-bells-ledger.js
+++ b/src/lib/ledgers/five-bells-ledger.js
@@ -141,7 +141,8 @@ FiveBellsLedger.prototype._autofund = function * () {
       name: this.credentials.username,
       balance: '1500000',
       connector: config.getIn(['server', 'base_uri']),
-      password: this.credentials.password
+      password: this.credentials.password,
+      fingerprint: this.credentials.fingerprint
     },
     cert: admin.cert,
     ca: admin.ca,


### PR DESCRIPTION
Also, add fingerprint when autofunding an account (debug feature) so it works
with client cert auth