### PR TITLE
Fix exception on payment that is missing the execution_condition

### DIFF
--- a/src/models/payments.js
+++ b/src/models/payments.js
@@ -28,6 +28,10 @@ function sourceConditionIsDestinationTransfer (source, destination) {
     state: 'executed'
   }
 
+  if (!source.execution_condition) {
+    return false
+  }
+
   if (source.execution_condition.message_hash &&
     source.execution_condition.message_hash !== hashJSON(expectedMessage)) {
     return false

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -245,6 +245,25 @@ describe('Notifications', function () {
       sourceTransferExecuted.done()
     })
 
+    it('should not cause server error if source transfer is missing execution_condition', function * () {
+      const payment = this.formatId(this.paymentOneToOne, '/payments/')
+
+      nock(payment.destination_transfers[0].id)
+        .put('')
+        .reply(201, _.assign({}, payment.destination_transfers[0], {
+          state: 'prepared'
+        }))
+
+      const notification = _.cloneDeep(this.notificationSourceTransferPrepared)
+      delete notification.resource.execution_condition
+
+      yield this.request()
+        .post('/notifications')
+        .send(notification)
+        .expect(200)
+        .end()
+    })
+
     it('should submit the source transfer corresponding to the destination transfer it is notified about if the execution conditions are the same', function * () {
       const payment = this.formatId(this.paymentSameExecutionCondition,
         '/payments/')


### PR DESCRIPTION
Addresses RILP-362. I'm not sure how to test this now since the payments endpoint was removed.