### PR TITLE
fix: allow using a CA with basic-auth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm start
     "account_uri": "...",
     "username": "...",
     "password": "..."
+    "ca": "...", // Optional
   },
 
   // Using Client Certificate Auth

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -30,21 +30,21 @@ function parseCredentialsEnv () {
 function parseCredentials () {
   const credentialsEnv = parseCredentialsEnv()
 
-  return _.reduce(credentialsEnv, (parsed, credentials, ledger) => {
+  return _.mapValues(credentialsEnv, (credentials) => {
     const isClientCertCredential = credentials.key !== undefined
 
     if (isClientCertCredential) {
-      parsed[ledger] = _.assign(credentials, {
+      return _.omitBy(_.assign(credentials, {
         key: fs.readFileSync(credentials.key),
         cert: fs.readFileSync(credentials.cert),
-        ca: credentials.cert && fs.readFileSync(credentials.ca)
-      })
-    } else {
-      parsed[ledger] = credentials
+        ca: credentials.ca && fs.readFileSync(credentials.ca)
+      }), _.isUndefined)
     }
 
-    return parsed
-  }, {})
+    return _.omitBy(_.assign(credentials, {
+      ca: credentials.ca && fs.readFileSync(credentials.ca)
+    }), _.isUndefined)
+  })
 }
 
 function parseAdminEnv () {


### PR DESCRIPTION
Previously, CA file was only parsed correctly when using client cert
authentication.

This correctly parses the file, which is useful if using self-signed
certificates in testing environments