### PR TITLE
[BREAKING] Dont use Transfers as Quotes

### DIFF
--- a/schemas/Quote.json
+++ b/schemas/Quote.json
@@ -4,6 +4,10 @@
   "description": "A quote object",
   "type": "object",
   "properties": {
+    "source_connector_account": {
+      "description": "the connector's account on the source ledger",
+      "$ref": "Iri.json"
+    },
     "source_ledger": {
       "description": "The URI of the source ledger",
       "$ref": "Iri.json"
@@ -19,8 +23,20 @@
     "destination_amount": {
       "description": "The amount in the currency used by the destination ledger",
       "$ref": "PositiveFiniteAmount.json"
-    }
+    },
+    "source_expiry_duration": {
+      "description": "Time in seconds between proposed_at and expires_at. Set in quotes from payment systems but not valid in actual transfers",
+      "$ref": "NonNegativeDuration.json"
+    },
+    "destination_expiry_duration": { "$ref": "NonNegativeDuration.json" }
   },
-  "required": ["source_ledger", "destination_ledger", "source_amount", "destination_amount"],
+  "required": [
+    "source_ledger",
+    "destination_ledger",
+    "source_amount",
+    "destination_amount",
+    "source_expiry_duration",
+    "destination_expiry_duration"
+  ],
   "additionalProperties": false
 }

--- a/src/controllers/quote.js
+++ b/src/controllers/quote.js
@@ -43,30 +43,13 @@ const InvalidAmountSpecifiedError = require('../errors/invalid-amount-specified-
  * @apiSuccessExample {json} 200 Quote Response:
  *    HTTP/1.1 200 OK
  *      {
- *        "source_transfers": [
- *          {
- *            "ledger": "http://eur-ledger.example/EUR",
- *            "credits": [
- *              {
- *                "account": "mark",
- *                "amount": "100.25"
- *              }
- *            ],
- *            "expiry_duration": "6000"
- *          }
- *        ],
- *        "destination_transfers": [
- *          {
- *            "ledger": "http://usd-ledger.example/USD",
- *            "debits": [
- *              {
- *                "amount": "105.71",
- *                "account": "mark"
- *              }
- *            ],
- *            "expiry_duration": "5000"
- *          }
- *        ]
+ *        "source_connector_account": "mark",
+ *        "source_ledger": "http://eur-ledger.example/EUR",
+ *        "source_amount": "100.25",
+ *        "source_expiry_duration": "6000",
+ *        "destination_ledger": "http://usd-ledger.example/USD",
+ *        "destination_amount": "105.71",
+ *        "destination_expiry_duration": "5000"
  *      }
  *
  * @apiExample {shell} Fixed Destination Amount:
@@ -80,30 +63,13 @@ const InvalidAmountSpecifiedError = require('../errors/invalid-amount-specified-
  * @apiSuccessExample {json} 200 Quote Response:
  *    HTTP/1.1 200 OK
  *      {
- *        "source_transfers": [
- *          {
- *            "ledger": "http://eur-ledger.example/EUR",
- *            "credits": [
- *              {
- *                "account": "mark",
- *                "amount": "100.25"
- *              }
- *            ],
- *            "expiry_duration": "6000"
- *          }
- *        ],
- *        "destination_transfers": [
- *          {
- *            "ledger": "http://usd-ledger.example/USD",
- *            "debits": [
- *              {
- *                "amount": "105.71",
- *                "account": "mark"
- *              }
- *            ],
- *            "expiry_duration": "5000"
- *          }
- *        ]
+ *        "source_connector_account": "mark",
+ *        "source_ledger": "http://eur-ledger.example/EUR",
+ *        "source_amount": "100.25",
+ *        "source_expiry_duration": "6000",
+ *        "destination_ledger": "http://usd-ledger.example/USD",
+ *        "destination_amount": "105.71",
+ *        "destination_expiry_duration": "5000"
  *      }
  *
  * @apiUse UnacceptableExpiryError

--- a/src/lib/route-builder.js
+++ b/src/lib/route-builder.js
@@ -26,12 +26,10 @@ class RouteBuilder {
   /**
    * @param {Object} query
    * @param {String} query.sourceLedger
-   * @param {String} query.sourceAccount
    * @param {String} query.sourceAmount
    * @param {String} query.destinationLedger
-   * @param {String} query.destinationAccount
    * @param {String} query.destinationAmount
-   * @returns {Transfer}
+   * @returns {Quote}
    */
   * getQuote (query) {
     const _nextHop = this._findNextHop(query)
@@ -44,19 +42,11 @@ class RouteBuilder {
     const nextHop = yield this._roundHop(_nextHop)
 
     return {
-      ledger: nextHop.sourceLedger,
-      debits: [{ account: query.sourceAccount, amount: nextHop.sourceAmount }],
-      credits: [{
-        account: this.ledgerCredentials[nextHop.sourceLedger].account_uri,
-        amount: nextHop.sourceAmount,
-        memo: {
-          destination_transfer: {
-            ledger: nextHop.finalLedger,
-            debits: [{ account: null, amount: nextHop.finalAmount }],
-            credits: [{ account: query.destinationAccount, amount: nextHop.finalAmount }]
-          }
-        }
-      }],
+      source_connector_account: this.ledgerCredentials[nextHop.sourceLedger].account_uri,
+      source_ledger: nextHop.sourceLedger,
+      source_amount: nextHop.sourceAmount,
+      destination_ledger: nextHop.finalLedger,
+      destination_amount: nextHop.finalAmount,
       _hop: nextHop
     }
   }

--- a/test/quoteSpec.js
+++ b/test/quoteSpec.js
@@ -345,16 +345,16 @@ describe('Quotes', function () {
         .end()
     })
 
-    it('should return a valid Transfer Template object', function * () {
+    it('should return a valid Quote object', function * () {
       yield this.request()
         .get('/quote?' +
           'source_amount=100' +
           '&source_ledger=http://eur-ledger.example/EUR' +
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(function (res) {
-          let validation = validate('TransferTemplate', res.body)
+          let validation = validate('Quote', res.body)
           if (!validation.valid) {
-            throw new Error('Not a valid transfer template')
+            throw new Error('Not a valid Quote')
           }
         })
         .end()
@@ -383,30 +383,13 @@ describe('Quotes', function () {
           '&source_ledger=http://eur-ledger.example/EUR' +
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(200, {
-          ledger: 'http://eur-ledger.example/EUR',
-          debits: [{
-            account: null,
-            amount: '100.00'
-          }],
-          credits: [{
-            account: 'http://eur-ledger.example/accounts/mark',
-            amount: '100.00',
-            memo: {
-              destination_transfer: {
-                ledger: 'http://usd-ledger.example/USD',
-                debits: [{
-                  amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                credits: [{
-                  amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://eur-ledger.example/accounts/mark',
+          source_ledger: 'http://eur-ledger.example/EUR',
+          source_amount: '100.00',
+          source_expiry_duration: '6',
+          destination_ledger: 'http://usd-ledger.example/USD',
+          destination_amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -434,30 +417,13 @@ describe('Quotes', function () {
           '&source_ledger=http://eur-ledger.example/EUR' +
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(200, {
-          ledger: 'http://eur-ledger.example/EUR',
-          debits: [{
-            account: null,
-            amount: '100.0000'
-          }],
-          credits: [{
-            account: 'http://eur-ledger.example/accounts/mark',
-            amount: '100.0000',
-            memo: {
-              destination_transfer: {
-                ledger: 'http://usd-ledger.example/USD',
-                debits: [{
-                  amount: '105.60', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                credits: [{
-                  amount: '105.60', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://eur-ledger.example/accounts/mark',
+          source_ledger: 'http://eur-ledger.example/EUR',
+          source_amount: '100.0000',
+          source_expiry_duration: '6',
+          destination_ledger: 'http://usd-ledger.example/USD',
+          destination_amount: '105.60', // EUR/USD Rate of 1.0592 - .2% spread - slippage
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -506,30 +472,13 @@ describe('Quotes', function () {
           '&source_ledger=http://eur-ledger.example/EUR' +
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(200, {
-          ledger: 'http://eur-ledger.example/EUR',
-          debits: [{
-            account: null,
-            amount: '100.0000'
-          }],
-          credits: [{
-            account: 'http://eur-ledger.example/accounts/mark',
-            amount: '100.0000',
-            memo: {
-              destination_transfer: {
-                ledger: 'http://usd-ledger.example/USD',
-                debits: [{
-                  amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                credits: [{
-                  amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://eur-ledger.example/accounts/mark',
+          source_ledger: 'http://eur-ledger.example/EUR',
+          source_amount: '100.0000',
+          source_expiry_duration: '6',
+          destination_ledger: 'http://usd-ledger.example/USD',
+          destination_amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -542,30 +491,13 @@ describe('Quotes', function () {
           '&destination_amount=100' +
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(200, {
-          ledger: 'http://eur-ledger.example/EUR',
-          debits: [{
-            account: null,
-            amount: '94.6947' // (1/ EUR/USD Rate of 1.0592) + .2% spread + round up to overestimate + slippage
-          }],
-          credits: [{
-            account: 'http://eur-ledger.example/accounts/mark',
-            amount: '94.6947', // (1/ EUR/USD Rate of 1.0592) + .2% spread + round up to overestimate + slippage
-            memo: {
-              destination_transfer: {
-                ledger: 'http://usd-ledger.example/USD',
-                debits: [{
-                  amount: '100.0000',
-                  account: null
-                }],
-                credits: [{
-                  amount: '100.0000',
-                  account: null
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://eur-ledger.example/accounts/mark',
+          source_ledger: 'http://eur-ledger.example/EUR',
+          source_amount: '94.6947', // (1/ EUR/USD Rate of 1.0592) + .2% spread + round up to overestimate + slippage
+          source_expiry_duration: '6',
+          destination_ledger: 'http://usd-ledger.example/USD',
+          destination_amount: '100.0000',
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -576,30 +508,13 @@ describe('Quotes', function () {
           '&source_ledger=http://eur-ledger.example/EUR' +
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(200, {
-          ledger: 'http://eur-ledger.example/EUR',
-          debits: [{
-            account: null,
-            amount: '100.0000'
-          }],
-          credits: [{
-            account: 'http://eur-ledger.example/accounts/mark',
-            amount: '100.0000',
-            memo: {
-              destination_transfer: {
-                ledger: 'http://usd-ledger.example/USD',
-                debits: [{
-                  amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                credits: [{
-                  amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
-                  account: null
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://eur-ledger.example/accounts/mark',
+          source_ledger: 'http://eur-ledger.example/EUR',
+          source_amount: '100.0000',
+          source_expiry_duration: '6',
+          destination_ledger: 'http://usd-ledger.example/USD',
+          destination_amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -610,30 +525,13 @@ describe('Quotes', function () {
           '&source_ledger=http://usd-ledger.example/USD' +
           '&destination_ledger=http://eur-ledger.example/EUR')
         .expect(200, {
-          ledger: 'http://usd-ledger.example/USD',
-          debits: [{
-            account: null,
-            amount: '100.0000'
-          }],
-          credits: [{
-            account: 'http://usd-ledger.example/accounts/mark',
-            amount: '100.0000',
-            memo: {
-              destination_transfer: {
-                ledger: 'http://eur-ledger.example/EUR',
-                debits: [{
-                  amount: '94.1278', // 1 / (EUR/USD Rate of 1.0592 + .2% spread) - slippage
-                  account: null
-                }],
-                credits: [{
-                  amount: '94.1278', // 1 / (EUR/USD Rate of 1.0592 + .2% spread) - slippage
-                  account: null
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://usd-ledger.example/accounts/mark',
+          source_ledger: 'http://usd-ledger.example/USD',
+          source_amount: '100.0000',
+          source_expiry_duration: '6',
+          destination_ledger: 'http://eur-ledger.example/EUR',
+          destination_amount: '94.1278', // 1 / (EUR/USD Rate of 1.0592 + .2% spread) - slippage
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -644,30 +542,13 @@ describe('Quotes', function () {
           '&source_ledger=http://usd-ledger.example/USD' +
           '&destination_ledger=http://cad-ledger.example:1000/CAD')
         .expect(200, {
-          ledger: 'http://usd-ledger.example/USD',
-          debits: [{
-            account: null,
-            amount: '100.0000'
-          }],
-          credits: [{
-            account: 'http://usd-ledger.example/accounts/mark',
-            amount: '100.0000',
-            memo: {
-              destination_transfer: {
-                ledger: 'http://cad-ledger.example:1000/CAD',
-                debits: [{
-                  amount: '127.8538', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread - slippage
-                  account: null
-                }],
-                credits: [{
-                  amount: '127.8538', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread - slippage
-                  account: null
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://usd-ledger.example/accounts/mark',
+          source_ledger: 'http://usd-ledger.example/USD',
+          source_amount: '100.0000',
+          source_expiry_duration: '6',
+          destination_ledger: 'http://cad-ledger.example:1000/CAD',
+          destination_amount: '127.8538', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread - slippage
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -678,30 +559,13 @@ describe('Quotes', function () {
           '&source_ledger=http://cad-ledger.example:1000/CAD' +
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(200, {
-          ledger: 'http://cad-ledger.example:1000/CAD',
-          debits: [{
-            amount: '100.0000',
-            account: null
-          }],
-          credits: [{
-            amount: '100.0000',
-            account: 'http://cad-ledger.example:1000/accounts/mark',
-            memo: {
-              destination_transfer: {
-                ledger: 'http://usd-ledger.example/USD',
-                debits: [{
-                  account: null,
-                  amount: '77.7460' // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread) - slippage
-                }],
-                credits: [{
-                  account: null,
-                  amount: '77.7460' // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread) - slippage
-                }],
-                expiry_duration: '5'
-              }
-            }
-          }],
-          expiry_duration: '6'
+          source_connector_account: 'http://cad-ledger.example:1000/accounts/mark',
+          source_ledger: 'http://cad-ledger.example:1000/CAD',
+          source_amount: '100.0000',
+          source_expiry_duration: '6',
+          destination_ledger: 'http://usd-ledger.example/USD',
+          destination_amount: '77.7460', // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread) - slippage
+          destination_expiry_duration: '5'
         })
         .end()
     })
@@ -713,10 +577,8 @@ describe('Quotes', function () {
           '&destination_ledger=http://usd-ledger.example/USD')
         .expect(200)
         .expect(function (res) {
-          expect(res.body.expiry_duration)
-            .to.equal('6')
-          expect(res.body.credits[0].memo.destination_transfer.expiry_duration)
-            .to.equal('5')
+          expect(res.body.source_expiry_duration).to.equal('6')
+          expect(res.body.destination_expiry_duration).to.equal('5')
         })
         .end()
     })
@@ -730,10 +592,8 @@ describe('Quotes', function () {
           '&destination_expiry_duration=5')
         .expect(200)
         .expect(function (res) {
-          expect(res.body.expiry_duration)
-            .to.equal('6')
-          expect(res.body.credits[0].memo.destination_transfer.expiry_duration)
-            .to.equal('5')
+          expect(res.body.source_expiry_duration).to.equal('6')
+          expect(res.body.destination_expiry_duration).to.equal('5')
         })
         .end()
     })
@@ -746,10 +606,8 @@ describe('Quotes', function () {
           '&destination_expiry_duration=5')
         .expect(200)
         .expect(function (res) {
-          expect(res.body.expiry_duration)
-            .to.equal('6')
-          expect(res.body.credits[0].memo.destination_transfer.expiry_duration)
-            .to.equal('5')
+          expect(res.body.source_expiry_duration).to.equal('6')
+          expect(res.body.destination_expiry_duration).to.equal('5')
         })
         .end()
     })
@@ -762,10 +620,8 @@ describe('Quotes', function () {
           '&source_expiry_duration=6')
         .expect(200)
         .expect(function (res) {
-          expect(res.body.expiry_duration)
-            .to.equal('6')
-          expect(res.body.credits[0].memo.destination_transfer.expiry_duration)
-            .to.equal('5')
+          expect(res.body.source_expiry_duration).to.equal('6')
+          expect(res.body.destination_expiry_duration).to.equal('5')
         })
         .end()
     })
@@ -781,10 +637,7 @@ describe('Quotes', function () {
           '&source_expiry_duration=6')
         .expect(200)
         .expect(function (res) {
-          expect(res.body.debits[0].account).to.equal('http://cad-ledger.example/accounts/foo')
-          const destinationTransfer = res.body.credits[0].memo.destination_transfer
-          expect(destinationTransfer.credits[0].account).to.equal(null)
-          expect(res.body.ledger).to.equal('http://cad-ledger.example:1000/CAD')
+          expect(res.body.source_ledger).to.equal('http://cad-ledger.example:1000/CAD')
         })
         .end()
       mockGet.done()
@@ -801,10 +654,7 @@ describe('Quotes', function () {
           '&source_expiry_duration=6')
         .expect(200)
         .expect(function (res) {
-          expect(res.body.debits[0].account).to.equal(null)
-          const destinationTransfer = res.body.credits[0].memo.destination_transfer
-          expect(destinationTransfer.credits[0].account).to.equal('http://usd-ledger.example/accounts/foo')
-          expect(destinationTransfer.ledger).to.equal('http://usd-ledger.example/USD')
+          expect(res.body.destination_ledger).to.equal('http://usd-ledger.example/USD')
         })
         .end()
       mockGet.done()
@@ -872,40 +722,29 @@ describe('Quotes', function () {
         .expect(200)
         .expect(function (res) {
           expect(res.body).to.deep.equal({
-            ledger: 'http://usd-ledger.example/USD',
-            debits: [{account: 'http://usd-ledger.example/accounts/alice', amount: '100.0000'}],
-            credits: [{
-              account: 'http://usd-ledger.example/accounts/mark',
-              amount: '100.0000',
-              memo: {
-                destination_transfer: {
-                  ledger: 'http://random-ledger.example/',
-                  debits: [{account: null, amount: '188.2556'}],
-                  credits: [{account: 'http://random-ledger.example/accounts/bob', amount: '188.2556'}],
-                  expiry_duration: '5'
-                }
-              }
-            }],
-            expiry_duration: '7'
+            source_connector_account: 'http://usd-ledger.example/accounts/mark',
+            source_ledger: 'http://usd-ledger.example/USD',
+            source_amount: '100.0000',
+            source_expiry_duration: '7',
+            destination_ledger: 'http://random-ledger.example/',
+            destination_amount: '188.2556',
+            destination_expiry_duration: '5'
           })
         })
         .end()
     })
 
-    it('quotes a same-ledger payment', function * () {
+    it('fails on a same-ledger payment', function * () {
       yield this.request()
         .get('/quote?source_amount=100' +
           '&source_ledger=' + encodeURIComponent('http://usd-ledger.example/USD') +
           '&source_account=' + encodeURIComponent('http://usd-ledger.example/accounts/alice') +
           '&destination_ledger=' + encodeURIComponent('http://usd-ledger.example/USD') +
           '&destination_account=' + encodeURIComponent('http://usd-ledger.example/accounts/bob'))
-        .expect(200)
+        .expect(422)
         .expect(function (res) {
-          expect(res.body).to.deep.equal({
-            ledger: 'http://usd-ledger.example/USD',
-            debits: [{account: 'http://usd-ledger.example/accounts/alice', amount: '100'}],
-            credits: [{account: 'http://usd-ledger.example/accounts/bob', amount: '100'}]
-          })
+          expect(res.body.id).to.equal('AssetsNotTradedError')
+          expect(res.body.message).to.match(/source_ledger must be different from destination_ledger/)
         })
     })
   })

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -68,19 +68,11 @@ describe('RouteBuilder', function () {
           sourceAmount: '100'
         })
         assert.deepStrictEqual(quoteTransfer, {
-          ledger: ledgerA,
-          debits: [{ account: aliceA, amount: '100.00' }],
-          credits: [{
-            account: markA,
-            amount: '100.00',
-            memo: {
-              destination_transfer: {
-                ledger: ledgerC,
-                debits: [{ account: null, amount: '24.75' }],
-                credits: [{ account: carlC, amount: '24.75' }]
-              }
-            }
-          }],
+          source_connector_account: markA,
+          source_ledger: ledgerA,
+          source_amount: '100.00',
+          destination_ledger: ledgerC,
+          destination_amount: '24.75',
           _hop: quoteTransfer._hop
         })
       })
@@ -96,19 +88,11 @@ describe('RouteBuilder', function () {
           destinationAmount: '25'
         })
         assert.deepStrictEqual(quoteTransfer, {
-          ledger: ledgerA,
-          debits: [{ account: aliceA, amount: '101.00' }],
-          credits: [{
-            account: markA,
-            amount: '101.00',
-            memo: {
-              destination_transfer: {
-                ledger: ledgerC,
-                debits: [{ account: null, amount: '25.00' }],
-                credits: [{ account: carlC, amount: '25.00' }]
-              }
-            }
-          }],
+          source_connector_account: markA,
+          source_ledger: ledgerA,
+          source_amount: '101.00',
+          destination_ledger: ledgerC,
+          destination_amount: '25.00',
           _hop: quoteTransfer._hop
         })
       })


### PR DESCRIPTION
Use the object found in `schemas/Quote.json` for Quotes instead of `Transfer`.

This will break any code that calls `/quote` directly.

The corresponding sender change is https://github.com/interledger/five-bells-sender/pull/69