### PR TITLE
Check ledgers' health before crawling / broadcasting routes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -59,6 +59,7 @@ function listen (koaApp, config, ledgers) {
   // Start a coroutine that connects to the backend and
   // subscribes to all the ledgers in the background
   co(function * () {
+    yield ledgers.checkLedgersHealth()
     yield backend.connect()
     yield routeBroadcaster.start()
     yield subscriptions.subscribePairs(config.get('tradingPairs'), ledgers, config)
@@ -72,6 +73,7 @@ function createApp (config, ledgers) {
 
   koaApp.context.config = config
   koaApp.context.ledgers = ledgers
+  koaApp.context.backend = backend
 
   // Configure passport
   const passport = new Passport()

--- a/src/backends/fixerio/index.js
+++ b/src/backends/fixerio/index.js
@@ -6,6 +6,7 @@ const BigNumber = require('bignumber.js')
 const NoAmountSpecifiedError = require('../../errors/no-amount-specified-error')
 const log = require('../../common').log('fixerio')
 const utils = require('../utils')
+const healthStatus = require('../../common/health.js')
 
 const RATES_API = 'https://api.fixer.io/latest'
 
@@ -56,6 +57,15 @@ class FixerIoBackend {
     this.rates[apiData.base] = 1
     this.currencies = _.keys(this.rates)
     this.currencies.sort()
+  }
+
+  /**
+   * Get backend status
+   */
+  * getStatus () {
+    return {
+      backendStatus: healthStatus.statusOk
+    }
   }
 
   _formatAmount (amount) {

--- a/src/backends/ilp-quoter/index.js
+++ b/src/backends/ilp-quoter/index.js
@@ -9,6 +9,7 @@ const UnsupportedPairError =
 const log = require('../../common').log('ilpquoter')
 const ServerError = require('five-bells-shared/errors/server-error')
 const utils = require('../utils')
+const healthStatus = require('../../common/health.js')
 
 /**
  * Example backend that connects to an external component to get
@@ -24,6 +25,7 @@ class ILPQuoter {
     this.currencyPairs = this.currencyWithLedgerPairs.map((p) => [p[0].slice(0, 3),
                                                                   p[1].slice(0, 3)])
     this.backendUri = opts.backendUri
+    this.backendStatus = healthStatus.statusNotOk
   }
 
   * putPair (uri) {
@@ -41,7 +43,18 @@ class ILPQuoter {
   * connect () {
     const uris = _.uniq(this.currencyPairs.map((pair) => this.backendUri + '/pair/' + pair[0] + '/' + pair[1]))
     yield uris.map((uri) => this.putPair(uri))
+    this.backendStatus = healthStatus.statusOk
     return
+  }
+
+  /**
+   * Get backend status
+   */
+  * getStatus () {
+    const status = {
+      backendStatus: this.backendStatus
+    }
+    return status
   }
 
   /**

--- a/src/backends/one-to-one.js
+++ b/src/backends/one-to-one.js
@@ -3,6 +3,7 @@
 const BigNumber = require('bignumber.js')
 const NoAmountSpecifiedError = require('../errors/no-amount-specified-error')
 const log = require('../common').log('one-to-one')
+const healthStatus = require('../common/health.js')
 
 /**
  * Backend which charges no spread and trades everything one-to-one.
@@ -25,6 +26,15 @@ class OneToOneBackend {
    * Nothing to do since this backend is totally static.
    */
   * connect (mockData) {
+  }
+
+  /**
+   * Get backend status
+   */
+  * getStatus () {
+    return {
+      backendStatus: healthStatus.statusOk
+    }
   }
 
   /**

--- a/src/common/health.js
+++ b/src/common/health.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  statusOk: 'OK',
+  statusNotOk: 'WAITING'
+}

--- a/src/controllers/health.js
+++ b/src/controllers/health.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const _ = require('lodash')
+const healthStatus = require('../common/health.js')
+
 /**
  * @api {get} /health Get server health status
  * @apiName GetHealth
@@ -14,6 +17,12 @@
  * @returns {void}
  */
 exports.getResource = function * health () {
-  // TODO: Add some checks, e.g. database status
-  this.body = {'status': 'OK'}
+  const backendStatus = yield this.backend.getStatus()
+  const ledgersStatus = yield this.ledgers.getStatus()
+  const body = _.extend({}, backendStatus, ledgersStatus)
+  body.status = (backendStatus.backendStatus === healthStatus.statusOk &&
+                 ledgersStatus.ledgersStatus === healthStatus.statusOk) ? healthStatus.statusOk
+                                                                        : healthStatus.statusNotOk
+  // TODO: add more status, ledger connection, quoter connection,...
+  this.body = body
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -13,6 +13,9 @@ const DEFAULT_MAX_HOLD_TIME = 10 // seconds
 const DEFAULT_FX_SPREAD = 0.002 // 0.2%
 const DEFAULT_SLIPPAGE = 0.001 // 0.1%
 
+const DEFAULT_ROUTE_BROADCAST_INTERVAL = 30 * 1000 // milliseconds
+const DEFAULT_ROUTE_CLEANUP_INTERVAL = 1000 // milliseconds
+
 function isRunningTests () {
   return (
     process.env.NODE_ENV === 'unit' ||
@@ -212,6 +215,11 @@ function getLocalConfig () {
   // when using the ilp-quote backend)
   const backendUri = Config.getEnv(envPrefix, 'BACKEND_URI')
 
+  const routeBroadcastInterval =
+    Number(Config.getEnv(envPrefix, 'ROUTE_BROADCAST_INTERVAL')) || DEFAULT_ROUTE_BROADCAST_INTERVAL
+  const routeCleanupInterval =
+    Number(Config.getEnv(envPrefix, 'ROUTE_CLEANUP_INTERVAL')) || DEFAULT_ROUTE_CLEANUP_INTERVAL
+
   // Credentials should be specified as a map of the form
   // {
   //    "<ledger_uri>": {
@@ -246,7 +254,9 @@ function getLocalConfig () {
     tradingPairs,
     server,
     backendUri,
-    notifications
+    notifications,
+    routeBroadcastInterval,
+    routeCleanupInterval
   }
 }
 

--- a/src/lib/ledgers/five-bells-ledger.js
+++ b/src/lib/ledgers/five-bells-ledger.js
@@ -180,6 +180,14 @@ FiveBellsLedger.prototype.unsubscribe = function * () {
   }, 'could not unsubscribe from ledger ' + this.id, this.credentials)
 }
 
+FiveBellsLedger.prototype.checkHealth = function * () {
+  log.info('checking health for ' + this.id)
+  yield requestRetry({
+    method: 'get',
+    url: this.id + '/health'
+  }, 'could not check health for ledger ' + this.id, this.credentials)
+}
+
 function wait (ms) {
   return function (done) {
     setTimeout(done, ms)

--- a/src/services/route-broadcaster.js
+++ b/src/services/route-broadcaster.js
@@ -8,5 +8,7 @@ module.exports = new RouteBroadcaster(
   {
     ledgerCredentials: config.ledgerCredentials,
     tradingPairs: config.tradingPairs,
-    minMessageWindow: config.expiry.minMessageWindow
+    minMessageWindow: config.expiry.minMessageWindow,
+    routeCleanupInterval: config.routeCleanupInterval,
+    routeBroadcastInterval: config.routeBroadcastInterval
   })


### PR DESCRIPTION
* Check health of all ledgers before to start broadcasting routes
* /health endpoint now returns some actual status on the backend and the routing 