### PR TITLE
BREAKING: ILP Packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,5 +137,5 @@ Breaking down that command:
 
 ## Payments
 
-The connector will facilitate an interledger payment upon receiving a notification for a transfer in which it is credited. That "source" transfer must have a `destination_transfer` in it's credit's `memo` that debits the connector.
+The connector will facilitate an interledger payment upon receiving a notification for a transfer in which it is credited. That "source" transfer must have a `ilp_header` in its credit's `memo` that specifies the payment's destination and amount.
 As soon as the source transfer is prepared, the connector will authorize the debits from its account(s) on the destination ledger.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eventemitter2": "^1.0.3",
     "five-bells-condition": "^3.2.0",
     "five-bells-routing": "~2.0.0",
-    "five-bells-shared": "^15.0.0",
+    "five-bells-shared": "^16.1.0",
     "koa": "^1.0.0",
     "koa-compress": "^1.0.6",
     "koa-cors": "0.0.16",

--- a/src/controllers/notifications.js
+++ b/src/controllers/notifications.js
@@ -124,7 +124,7 @@ exports.post = function * postNotification () {
       }
       return
     } else {
-      // TODO: Currently an invalid destination_transfer memo still triggers a
+      // TODO: Currently an invalid ilp_header memo still triggers a
       //   400 response. Invalid memos of any kind should be a 200 with result
       //   "ignored".
       log.error('Notification handling received critical error: ' + e)

--- a/src/models/payments.js
+++ b/src/models/payments.js
@@ -4,6 +4,11 @@ const testPaymentExpiry = require('../lib/testPaymentExpiry')
 const log = require('../common').log('payments')
 const executeSourceTransfer = require('../lib/executeSourceTransfer')
 const routeBuilder = require('../services/route-builder')
+const validator = require('../lib/validate')
+
+function validateIlpHeader (sourceTransfer) {
+  validator.validate('IlpHeader', sourceTransfer.data.ilp_header)
+}
 
 function * validateExpiry (sourceTransfer, destinationTransfer, config) {
   // TODO tie the maxHoldTime to the fx rate
@@ -16,14 +21,13 @@ function * validateExpiry (sourceTransfer, destinationTransfer, config) {
 function * settle (sourceTransfer, destinationTransfer, config, ledgers) {
   log.debug('Settle payment, source: ' + JSON.stringify(sourceTransfer))
   log.debug('Settle payment, destination: ' + JSON.stringify(destinationTransfer))
-
   yield ledgers.getLedger(destinationTransfer.ledger).send(destinationTransfer)
 }
 
 function * updateIncomingTransfer (sourceTransfer, ledgers, config) {
-  // TODO this is cheating, but how do we know the type of the final transfer's ledger?
-  const destinationTransfer = sourceTransfer.data.destination_transfer =
-    yield routeBuilder.getDestinationTransfer(sourceTransfer)
+  validateIlpHeader(sourceTransfer)
+
+  const destinationTransfer = yield routeBuilder.getDestinationTransfer(sourceTransfer)
 
   yield validateExpiry(sourceTransfer, destinationTransfer, config)
   yield settle(sourceTransfer, destinationTransfer, config, ledgers)

--- a/test/data/notificationDestinationTransferAtomic_TwoCases.json
+++ b/test/data/notificationDestinationTransferAtomic_TwoCases.json
@@ -1,0 +1,24 @@
+{
+  "id": "http://eur-ledger.example/transfers/3968e526-b5ef-4c35-8923-0e7cfd0892d3",
+  "ledger": "http://eur-ledger.example",
+  "debits":[{
+    "amount":"1.00",
+    "account":"http://eur-ledger.example/accounts/mark",
+    "memo": {
+      "source_transfer_ledger": "http://usd-ledger.example",
+      "source_transfer_id": "6851929f-5a91-4d02-b9f4-4ae6b7f1768c"
+    }
+  }],
+  "credits":[{
+    "amount":"1.00",
+    "account":"http://eur-ledger.example/accounts/bob"
+  }],
+  "execution_condition": "cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7",
+  "cancellation_condition": "cc:0:3:I3TZF5S3n0-07JWH0s8ArsxPmVP6s-0d0SqxR6C3Ifk:6",
+  "additional_info": {
+    "cases": [
+      "http://notary.example/cases/2cd5bcdb-46c9-4243-ac3f-79046a87a086",
+      "http://notary.example/cases/2cd5bcdb-46c9-4243-ac3f-79046a87a087"
+    ]
+  }
+}

--- a/test/data/notificationDestinationTransferPrepared.json
+++ b/test/data/notificationDestinationTransferPrepared.json
@@ -1,0 +1,19 @@
+{
+  "id": "http://eur-ledger.example/transfers/3968e526-b5ef-4c35-8923-0e7cfd0892d3",
+  "ledger": "http://eur-ledger.example",
+  "debits":[{
+    "amount":"1.00",
+    "account":"http://eur-ledger.example/accounts/mark",
+    "memo": {
+      "source_transfer_ledger": "http://usd-ledger.example",
+      "source_transfer_id": "6851929f-5a91-4d02-b9f4-4ae6b7f1768c"
+    }
+  }],
+  "credits":[{
+    "amount":"1.00",
+    "account":"http://eur-ledger.example/accounts/bob"
+  }],
+  "execution_condition": "cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7",
+  "expires_at": "2015-06-16T00:00:02.000Z",
+  "state": "proposed"
+}

--- a/test/data/notificationSourceTransferAtomic.json
+++ b/test/data/notificationSourceTransferAtomic.json
@@ -12,27 +12,10 @@
       "amount":"1.07",
       "account":"http://usd-ledger.example/accounts/mark",
       "memo":{
-        "destination_transfer": {
-          "id": "http://eur-ledger.example/transfers/c92f2a2c-b21d-4e6c-96e7-4f6d6df4bee9",
+        "ilp_header": {
           "ledger":"http://eur-ledger.example",
-          "debits":[{
-            "amount":"1.00",
-            "account":"http://eur-ledger.example/accounts/mark",
-            "memo": {
-              "source_transfer_ledger": "http://usd-ledger.example",
-              "source_transfer_id": "6851929f-5a91-4d02-b9f4-4ae6b7f1768c"
-            }
-          }],
-          "credits":[{
-            "amount":"1.00",
-            "account":"http://eur-ledger.example/accounts/bob"
-          }],
-          "execution_condition": "cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7",
-          "cancellation_condition": "cc:0:3:I3TZF5S3n0-07JWH0s8ArsxPmVP6s-0d0SqxR6C3Ifk:6",
-          "additional_info": {
-            "cases": [ "http://notary.example/cases/2cd5bcdb-46c9-4243-ac3f-79046a87a086" ]
-          },
-          "state": "proposed"
+          "amount":"1.00",
+          "account":"http://eur-ledger.example/accounts/bob"
         }
       }
     }],

--- a/test/data/notificationSourceTransferAtomic_TwoCases.json
+++ b/test/data/notificationSourceTransferAtomic_TwoCases.json
@@ -12,29 +12,10 @@
       "amount":"1.07",
       "account":"http://usd-ledger.example/accounts/mark",
       "memo":{
-        "destination_transfer": {
-          "id": "http://eur-ledger.example/transfers/c92f2a2c-b21d-4e6c-96e7-4f6d6df4bee9",
+        "ilp_header": {
           "ledger":"http://eur-ledger.example",
-          "debits":[{
-            "amount":"1.00",
-            "account":"http://eur-ledger.example/accounts/mark",
-            "memo": {
-              "source_transfer_ledger": "http://usd-ledger.example",
-              "source_transfer_id": "6851929f-5a91-4d02-b9f4-4ae6b7f1768c"
-            }
-          }],
-          "credits":[{
-            "amount":"1.00",
-            "account":"http://eur-ledger.example/accounts/bob"
-          }],
-          "execution_condition": "cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7",
-          "cancellation_condition": "cc:0:3:I3TZF5S3n0-07JWH0s8ArsxPmVP6s-0d0SqxR6C3Ifk:6",
-          "additional_info": {
-            "cases": [
-              "http://notary.example/cases/2cd5bcdb-46c9-4243-ac3f-79046a87a086",
-              "http://notary.example/cases/2cd5bcdb-46c9-4243-ac3f-79046a87a087"
-            ]
-          }
+          "amount":"1.00",
+          "account":"http://eur-ledger.example/accounts/bob"
         }
       }
     }],

--- a/test/data/notificationSourceTransferPrepared.json
+++ b/test/data/notificationSourceTransferPrepared.json
@@ -12,24 +12,10 @@
       "amount":"1.07",
       "account":"http://usd-ledger.example/accounts/mark",
       "memo":{
-        "destination_transfer": {
-          "id": "http://eur-ledger.example/transfers/c92f2a2c-b21d-4e6c-96e7-4f6d6df4bee9",
+        "ilp_header": {
           "ledger":"http://eur-ledger.example",
-          "debits":[{
-            "amount":"1.00",
-            "account":"http://eur-ledger.example/accounts/mark",
-            "memo": {
-              "source_transfer_ledger": "http://usd-ledger.example",
-              "source_transfer_id": "6851929f-5a91-4d02-b9f4-4ae6b7f1768c"
-            }
-          }],
-          "credits":[{
-            "amount":"1.00",
-            "account":"http://eur-ledger.example/accounts/bob"
-          }],
-          "execution_condition": "cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7",
-          "expires_at": "2015-06-16T00:00:02.000Z",
-          "state": "proposed"
+          "amount":"1.00",
+          "account":"http://eur-ledger.example/accounts/bob"
         }
       }
     }],

--- a/test/data/paymentOneToOne.json
+++ b/test/data/paymentOneToOne.json
@@ -16,7 +16,7 @@
     "state": "prepared"
   }],
   "destination_transfers":[{
-    "id": "http://eur-ledger.example/transfers/c92f2a2c-b21d-4e6c-96e7-4f6d6df4bee9",
+    "id": "http://eur-ledger.example/transfers/3968e526-b5ef-4c35-8923-0e7cfd0892d3",
     "ledger":"http://eur-ledger.example",
     "debits":[{
       "amount":"1.00",

--- a/test/data/paymentSameExecutionCondition.json
+++ b/test/data/paymentSameExecutionCondition.json
@@ -16,7 +16,7 @@
     "state": "prepared"
   }],
   "destination_transfers":[{
-    "id": "http://eur-ledger.example/transfers/c92f2a2c-b21d-4e6c-96e7-4f6d6df4bee9",
+    "id": "http://eur-ledger.example/transfers/3968e526-b5ef-4c35-8923-0e7cfd0892d3",
     "ledger":"http://eur-ledger.example",
     "debits":[{
       "amount":"1.00",

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -117,16 +117,15 @@ describe('RouteBuilder', function () {
         account: aliceA,
         amount: '100',
         data: {
-          destination_transfer: {
-            id: 'e901de57-0c9e-44f7-877a-ce98c84d3e0c',
+          ilp_header: {
             ledger: ledgerB,
-            debits: [{account: null, amount: '50'}],
-            credits: [{account: bobB, amount: '50'}]
+            account: bobB,
+            amount: '50'
           }
         }
       })
       assert.deepEqual(destinationTransfer, {
-        id: 'e901de57-0c9e-44f7-877a-ce98c84d3e0c',
+        id: 'c88dc516-ad0e-4a48-85ac-9dd08b3e72f3',
         ledger: ledgerB,
         direction: 'outgoing',
         account: bobB,
@@ -146,16 +145,15 @@ describe('RouteBuilder', function () {
         account: aliceA,
         amount: '100',
         data: {
-          destination_transfer: {
-            id: '219d7e92-d99b-4022-8e52-6f8510f671e6',
+          ilp_header: {
             ledger: ledgerB,
-            debits: [{account: ledgerB + '/accounts/bogus', amount: '50'}],
-            credits: [{account: bobB, amount: '50'}]
+            account: bobB,
+            amount: '50'
           }
         }
       })
       assert.deepEqual(destinationTransfer, {
-        id: '219d7e92-d99b-4022-8e52-6f8510f671e6',
+        id: '13eff292-b343-452d-8fc4-4833741a6186',
         ledger: ledgerB,
         direction: 'outgoing',
         account: bobB,
@@ -187,11 +185,10 @@ describe('RouteBuilder', function () {
           account: aliceA,
           amount: '100',
           data: {
-            destination_transfer: {
-              id: '456',
+            ilp_header: {
               ledger: ledgerC,
-              debits: [{account: null, amount: '25'}],
-              credits: [{account: carlC, amount: '25'}]
+              account: carlC,
+              amount: '25'
             }
           },
           executionCondition: 'yes',
@@ -205,11 +202,10 @@ describe('RouteBuilder', function () {
           account: maryB,
           amount: '50.00',
           data: {
-            destination_transfer: {
-              id: '456',
+            ilp_header: {
               ledger: ledgerC,
-              debits: [{account: null, amount: '25'}],
-              credits: [{account: carlC, amount: '25'}]
+              account: carlC,
+              amount: '25'
             }
           },
           noteToSelf: {
@@ -232,11 +228,10 @@ describe('RouteBuilder', function () {
           account: aliceA,
           amount: '100',
           data: {
-            destination_transfer: {
-              id: '456',
+            ilp_header: {
               ledger: ledgerC,
-              debits: [{account: null, amount: '50'}],
-              credits: [{account: carlC, amount: '50'}]
+              account: carlC,
+              amount: '50'
             }
           }
         })
@@ -252,7 +247,7 @@ describe('RouteBuilder', function () {
           amount: '100',
           data: {}
         })
-      }.bind(this), error('source transfer is missing destination_transfer in memo'))
+      }.bind(this), error('source transfer is missing ilp_header in memo'))
     })
   })
 })

--- a/test/subscriptionSpec.js
+++ b/test/subscriptionSpec.js
@@ -84,7 +84,11 @@ describe('Subscriptions', function () {
       event: 'transfer.update',
       resource: _.merge({}, payment.source_transfers[0], {
         credits: [{
-          memo: {destination_transfer: payment.destination_transfers[0]}
+          memo: { ilp_header: {
+            ledger: payment.destination_transfers[0].ledger,
+            amount: payment.destination_transfers[0].credits[0].amount,
+            account: payment.destination_transfers[0].credits[0].account
+          } }
         }]
       })
     }))


### PR DESCRIPTION
In order to support different types of ledgers, the information that travels with the transfer should be ledger-agnostic. We've identified the minimum set of fields necessary to get the payment to its destination: `destinationAccount` and `destinationAmount`, called the ILP packet or ILP header.

This PR changes the format of the transfer memos to include the ILP header instead of the destination_transfer object as before.

This PR build on #159 which should be merged first.

Related PRs:

interledger/five-bells-notary#65
interledger/five-bells-shared#142
interledger/five-bells-sender#72