### PR TITLE
Explain parameter for /quote to get information about how amounts are computed

### DIFF
--- a/schemas/Quote.json
+++ b/schemas/Quote.json
@@ -28,7 +28,11 @@
       "description": "Time in seconds between proposed_at and expires_at. Set in quotes from payment systems but not valid in actual transfers",
       "$ref": "NonNegativeDuration.json"
     },
-    "destination_expiry_duration": { "$ref": "NonNegativeDuration.json" }
+    "destination_expiry_duration": { "$ref": "NonNegativeDuration.json" },
+    "additional_info": {
+      "description": "Additional information related to the quote",
+      "type": "object"
+    }
   },
   "required": [
     "source_ledger",

--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -111,6 +111,7 @@ class RouteBroadcaster {
     return {
       source_ledger: quote.source_ledger,
       destination_ledger: quote.destination_ledger,
+      additional_info: quote.additional_info,
       connector: this.baseURI,
       min_message_window: this.minMessageWindow,
       source_account: this.ledgers.getLedger(quote.source_ledger).getAccount(),

--- a/src/lib/route-builder.js
+++ b/src/lib/route-builder.js
@@ -34,16 +34,23 @@ class RouteBuilder {
    * @returns {Quote}
    */
   * getQuote (query) {
+    const info = {}
     const _nextHop = this._findNextHop(query)
     if (!_nextHop) throwAssetsNotTradedError()
     if (query.sourceAmount) {
-      _nextHop.finalAmount = (new BigNumber(_nextHop.finalAmount)).times(1 - this.slippage).toString()
+      const amount = new BigNumber(_nextHop.finalAmount)
+      const amountWithSlippage = amount.times(1 - this.slippage)
+      _nextHop.finalAmount = amountWithSlippage.toString()
+      info.slippage = (amount - amountWithSlippage).toString()
     } else { // fixed destinationAmount
-      _nextHop.sourceAmount = (new BigNumber(_nextHop.sourceAmount)).times(1 + this.slippage).toString()
+      const amount = new BigNumber(_nextHop.sourceAmount)
+      const amountWithSlippage = amount.times(1 + this.slippage)
+      _nextHop.sourceAmount = amountWithSlippage.toString()
+      info.slippage = (amount - amountWithSlippage).toString()
     }
     const nextHop = yield this._roundHop(_nextHop)
 
-    return {
+    const quote = {
       source_connector_account:
         this.ledgers.getLedger(nextHop.sourceLedger).getAccount(),
       source_ledger: nextHop.sourceLedger,
@@ -52,6 +59,12 @@ class RouteBuilder {
       destination_amount: nextHop.finalAmount,
       _hop: nextHop
     }
+
+    if (query.explain) {
+      quote.additional_info = _.assign({}, nextHop.additionalInfo, info)
+    }
+
+    return quote
   }
 
   /**

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -23,7 +23,8 @@ class RoutingTables {
         (this.sources[localRoute.source_ledger] = new routing.RoutingTable())
       const route = new routing.Route(localRoute.points, {
         minMessageWindow: localRoute.min_message_window,
-        nextLedger: localRoute.destination_ledger
+        nextLedger: localRoute.destination_ledger,
+        additional_info: localRoute.additional_info
       })
       table.addRoute(localRoute.destination_ledger, this.baseURI, route)
     }
@@ -144,6 +145,7 @@ class RoutingTables {
     const ledgerB = nextHop.info.nextLedger
     const routeFromAToB = this._getLocalRoute(ledgerA, ledgerB)
     const isLocal = this.baseURI === nextHop.bestHop
+
     return {
       connector: nextHop.bestHop,
       sourceLedger: ledgerA,
@@ -155,7 +157,8 @@ class RoutingTables {
       destinationCreditAccount: isLocal ? null : this._getAccount(nextHop.bestHop, ledgerB),
       finalLedger: ledgerC,
       finalAmount: finalAmount,
-      minMessageWindow: nextHop.info.minMessageWindow
+      minMessageWindow: nextHop.info.minMessageWindow,
+      additionalInfo: isLocal ? routeFromAToB.info.additional_info : undefined
     }
   }
 
@@ -171,6 +174,7 @@ class RoutingTables {
     const ledgerB = nextHop.info.nextLedger
     const routeFromAToB = this._getLocalRoute(ledgerA, ledgerB)
     const isLocal = this.baseURI === nextHop.bestHop
+
     return {
       connector: nextHop.bestHop,
       sourceLedger: ledgerA,
@@ -181,7 +185,8 @@ class RoutingTables {
       destinationCreditAccount: isLocal ? null : this._getAccount(nextHop.bestHop, ledgerB),
       finalLedger: ledgerC,
       finalAmount: nextHop.bestValue.toString(),
-      minMessageWindow: nextHop.info.minMessageWindow
+      minMessageWindow: nextHop.info.minMessageWindow,
+      additionalInfo: isLocal ? routeFromAToB.info.additional_info : undefined
     }
   }
 

--- a/src/models/quote.js
+++ b/src/models/quote.js
@@ -14,11 +14,13 @@ function * makeQuoteQuery (params) {
     (yield getAccountLedger(params.source_account))
   const destinationLedger = params.destination_ledger ||
     (yield getAccountLedger(params.destination_account))
+  const explain = params.explain === 'true'
   return {
     sourceLedger,
     destinationLedger,
     sourceAmount: params.source_amount,
-    destinationAmount: params.destination_amount
+    destinationAmount: params.destination_amount,
+    explain
   }
 }
 

--- a/test/ilpQuoterSpec.js
+++ b/test/ilpQuoterSpec.js
@@ -49,7 +49,7 @@ describe('ILPQuoter', function () {
                       .put('/pair/EUR/USD').reply(200)
                       .put('/pair/USD/EUR').reply(200)
       yield this.backend.connect()
-      scope.isDone()
+      expect(scope.isDone()).to.be.true
     })
 
     it('should make sure unsupported pair is handled correctly', function * () {
@@ -59,7 +59,7 @@ describe('ILPQuoter', function () {
                       .put('/pair/XRP/USD').reply(400)
                       .put('/pair/USD/EUR').reply(200)
       yield yieldAndAssertException(this.backend.connect(), UnsupportedPairError)
-      scope.isDone()
+      expect(scope.isDone()).to.be.true
     })
 
     it('should fail for a quote with a missing source_ledger', function * () {
@@ -90,7 +90,7 @@ describe('ILPQuoter', function () {
       const quoteResponse = yield this.backend.getQuote(quote)
       expect(quoteResponse.source_amount).to.be.equal(123.89)
       expect(quoteResponse.destination_amount).to.be.equal(88.77)
-      scope.isDone()
+      expect(scope.isDone()).to.be.true
     })
 
     it('should make sure a valid quote returns with correct destination amount', function * () {
@@ -103,7 +103,7 @@ describe('ILPQuoter', function () {
       const quoteResponse = yield this.backend.getQuote(quote)
       expect(quoteResponse.source_amount).to.be.equal(99.77)
       expect(quoteResponse.destination_amount).to.be.equal(123.89)
-      scope.isDone()
+      expect(scope.isDone()).to.be.true
     })
 
     it('should make sure an error is thrown if the quoter returns a 404', function * () {
@@ -114,7 +114,7 @@ describe('ILPQuoter', function () {
       const scope = nock(this.backendUri)
                       .get('/quote/EUR/USD/123.89/source').reply(404)
       yield yieldAndAssertException(this.backend.getQuote(quote), ServerError)
-      scope.isDone()
+      expect(scope.isDone()).to.be.true
     })
 
     it('should make sure an error is thrown if the quoter returns a 500', function * () {
@@ -125,7 +125,7 @@ describe('ILPQuoter', function () {
       const scope = nock(this.backendUri)
                       .get('/quote/EUR/USD/123.89/source').reply(500)
       yield yieldAndAssertException(this.backend.getQuote(quote), ServerError)
-      scope.isDone()
+      expect(scope.isDone()).to.be.true
     })
   })
 })

--- a/test/routeBroadcasterSpec.js
+++ b/test/routeBroadcasterSpec.js
@@ -20,7 +20,8 @@ describe('RouteBroadcaster', function () {
       min_message_window: 1,
       source_account: ledgerA + '/accounts/mark',
       destination_account: ledgerB + '/accounts/mark',
-      points: [ [0, 0], [200, 100] ]
+      points: [ [0, 0], [200, 100] ],
+      additional_info: {}
     }, {
       source_ledger: ledgerB,
       destination_ledger: ledgerA,
@@ -28,7 +29,8 @@ describe('RouteBroadcaster', function () {
       min_message_window: 1,
       source_account: ledgerB + '/accounts/mark',
       destination_account: ledgerA + '/accounts/mark',
-      points: [ [0, 0], [100, 200] ]
+      points: [ [0, 0], [100, 200] ],
+      additional_info: {}
     }])
 
     this.broadcaster = new RouteBroadcaster(this.tables, this.backend, this.ledgers, {
@@ -40,7 +42,8 @@ describe('RouteBroadcaster', function () {
       destination_ledger: ledgerC,
       connector: 'http://other-connector2.example',
       min_message_window: 1,
-      points: [ [0, 0], [50, 60] ]
+      points: [ [0, 0], [50, 60] ],
+      additional_info: {}
     })
   })
 
@@ -97,6 +100,7 @@ describe('RouteBroadcaster', function () {
         }), {
           source_ledger: ledgerA,
           destination_ledger: ledgerB,
+          additional_info: undefined,
           connector: 'http://connector.example',
           min_message_window: 1,
           source_account: ledgerA + '/accounts/mark',

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -34,7 +34,8 @@ describe('RouteBuilder', function () {
       source_account: markA,
       destination_account: markB,
       min_message_window: 1,
-      points: [ [0, 0], [200, 100] ]
+      points: [ [0, 0], [200, 100] ],
+      additional_info: { rate_info: 'someInfoAboutTheRate' }
     }])
     this.builder = new RouteBuilder(this.tables, this.infoCache, this.ledgers, {
       minMessageWindow: 1,
@@ -55,13 +56,37 @@ describe('RouteBuilder', function () {
     })
 
     describe('fixed sourceAmount', function () {
+      it('Local quote should return additional info', function * () {
+        const quoteTransfer = yield this.builder.getQuote({
+          sourceLedger: ledgerA,
+          sourceAccount: aliceA,
+          destinationLedger: ledgerB,
+          destinationAccount: bobB,
+          sourceAmount: '200',
+          explain: 'true'
+        })
+        assert.deepStrictEqual(quoteTransfer, {
+          source_connector_account: markA,
+          source_ledger: ledgerA,
+          source_amount: '200.00',
+          destination_ledger: ledgerB,
+          destination_amount: '99.00',
+          _hop: quoteTransfer._hop,
+          additional_info: { rate_info: 'someInfoAboutTheRate',
+                             slippage: '1' }
+        })
+      })
+    })
+
+    describe('fixed sourceAmount', function () {
       it('returns a quote with slippage in the final amount', function * () {
         const quoteTransfer = yield this.builder.getQuote({
           sourceLedger: ledgerA,
           sourceAccount: aliceA,
           destinationLedger: ledgerC,
           destinationAccount: carlC,
-          sourceAmount: '100'
+          sourceAmount: '100',
+          explain: 'true'
         })
         assert.deepStrictEqual(quoteTransfer, {
           source_connector_account: markA,
@@ -69,7 +94,8 @@ describe('RouteBuilder', function () {
           source_amount: '100.00',
           destination_ledger: ledgerC,
           destination_amount: '24.75',
-          _hop: quoteTransfer._hop
+          _hop: quoteTransfer._hop,
+          additional_info: { slippage: '0.25' }
         })
       })
     })
@@ -81,7 +107,8 @@ describe('RouteBuilder', function () {
           sourceAccount: aliceA,
           destinationLedger: ledgerC,
           destinationAccount: carlC,
-          destinationAmount: '25'
+          destinationAmount: '25',
+          explain: 'true'
         })
         assert.deepStrictEqual(quoteTransfer, {
           source_connector_account: markA,
@@ -89,7 +116,8 @@ describe('RouteBuilder', function () {
           source_amount: '101.00',
           destination_ledger: ledgerC,
           destination_amount: '25.00',
-          _hop: quoteTransfer._hop
+          _hop: quoteTransfer._hop,
+          additional_info: { slippage: '-1' }
         })
       })
 

--- a/test/routingTablesSpec.js
+++ b/test/routingTablesSpec.js
@@ -23,7 +23,8 @@ describe('RoutingTables', function () {
       min_message_window: 1,
       source_account: markA,
       destination_account: markB,
-      points: [ [0, 0], [200, 100] ]
+      points: [ [0, 0], [200, 100] ],
+      additional_info: { rate_info: '0.5' }
     }, {
       source_ledger: ledgerB,
       destination_ledger: ledgerA,
@@ -31,7 +32,8 @@ describe('RoutingTables', function () {
       min_message_window: 1,
       source_account: markB,
       destination_account: markA,
-      points: [ [0, 0], [100, 200] ]
+      points: [ [0, 0], [100, 200] ],
+      additional_info: { rate_info: '2.0' }
     }])
   })
 
@@ -328,7 +330,8 @@ describe('RoutingTables', function () {
           destinationCreditAccount: ledgerB + '/accounts/mary',
           finalLedger: ledgerC,
           finalAmount: '25',
-          minMessageWindow: 2
+          minMessageWindow: 2,
+          additionalInfo: undefined
         })
     })
 
@@ -345,7 +348,8 @@ describe('RoutingTables', function () {
           destinationCreditAccount: null,
           finalLedger: ledgerB,
           finalAmount: '50',
-          minMessageWindow: 1
+          minMessageWindow: 1,
+          additionalInfo: { rate_info: '0.5' }
         })
     })
   })
@@ -364,7 +368,8 @@ describe('RoutingTables', function () {
           destinationCreditAccount: null,
           finalLedger: ledgerB,
           finalAmount: (50).toString(),
-          minMessageWindow: 1
+          minMessageWindow: 1,
+          additionalInfo: { rate_info: '0.5' }
         })
     })
   })


### PR DESCRIPTION
* If `explain` parameter is set to `true` during a quote, an additional info field will be included in the response
* The base rate will be included iff the quote is local
* Aggregating additional info when a multi hop payment needs to be defined further and is not yet implemented. No non-local quotes will not return additional info.
* More fields for fees, slippage, spread to be added at a later stage.