### PR TITLE
Fix: Support ILP-Plugin-Virtual

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "five-bells-routing": "~3.1.0",
     "five-bells-shared": "^16.1.0",
     "ilp-plugin-bells": "^2.1.1",
+    "ilp-plugin-virtual": "^1.2.0",
     "koa": "^1.0.0",
     "koa-compress": "^1.0.6",
     "koa-cors": "0.0.16",
@@ -58,6 +59,7 @@
     "passport-client-certificate": "^0.1.1",
     "reconnect-core": "^1.2.0",
     "spdy": "^3.2.3",
+    "sqlite3": "^3.1.4",
     "uuid4": "^1.0.0",
     "ws": "^1.1.0"
   },

--- a/src/lib/multiledger.js
+++ b/src/lib/multiledger.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash')
 const healthStatus = require('../common/health.js')
+const newSqliteStore = require('../lib/sqliteStore.js')
 
 function Multiledger (options) {
   this.config = options.config
@@ -22,12 +23,14 @@ Multiledger.prototype.getLedgers = function () {
 Multiledger.prototype.buildLedgers = function () {
   const ledgers = {}
   Object.keys(this.config.get('ledgerCredentials')).forEach((ledgerId) => {
-    const creds = this.config.getIn(['ledgerCredentials', ledgerId])
+    const creds = _.clone(this.config.getIn(['ledgerCredentials', ledgerId]))
+    const store = creds.store && newSqliteStore(creds.store)
 
     const LedgerPlugin = require('ilp-plugin-' + creds.type)
     ledgers[ledgerId] = new LedgerPlugin({
       id: ledgerId,
       auth: creds,
+      store: store,
       debugReplyNotifications: this.config.features.debugReplyNotifications,
       log: this.makeLogger('plugin-' + creds.type),
       connector: this.config.getIn(['server', 'base_uri'])

--- a/src/lib/sqliteStore.js
+++ b/src/lib/sqliteStore.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const sqlite3 = require('sqlite3').verbose()
+
+function newSqliteStore (address) {
+  address = address || ':memory:'
+
+  const db = new sqlite3.Database(address)
+  db.run('CREATE TABLE IF NOT EXISTS store (key TEXT, value TEXT)', () => {
+    db.run('CREATE UNIQUE INDEX IF NOT EXISTS id ON store (key)')
+  })
+
+  const put = function (k, v) {
+    return new Promise((resolve) => {
+      db.run('REPLACE INTO store (key, value) VALUES (?, ?)', k, v, () => {
+        resolve()
+      })
+    })
+  }
+
+  const get = function (k) {
+    return new Promise((resolve) => {
+      let items = []
+      db.each('SELECT key, value FROM store WHERE (key == ?)', k, (key, v) => {
+        items.push(v.value)
+      }, () => {
+        resolve(items[0] || undefined)
+      })
+    })
+  }
+
+  const del = function (k) {
+    return new Promise((resolve) => {
+      db.run('DELETE FROM store WHERE (key == ?)', k, () => {
+        resolve()
+      })
+    })
+  }
+
+  return { get: get, put: put, del: del }
+}
+
+module.exports = newSqliteStore

--- a/test/storeSpec.js
+++ b/test/storeSpec.js
@@ -1,0 +1,31 @@
+'use strict'
+const newSqliteStore = require('../src/lib/sqliteStore')
+const assert = require('chai').assert
+
+describe('SqliteStore', function () {
+  let obj = null
+  it('should create an object', () => {
+    obj = newSqliteStore()
+    assert.isObject(obj)
+  })
+
+  it('should support deletion', function (done) {
+    obj.put('k', 'v').then(() => {
+      return obj.del('k')
+    }).then(() => {
+      return obj.get('k')
+    }).then((value) => {
+      assert(value === undefined)
+      done()
+    })
+  })
+
+  it('should support adding elements', function (done) {
+    obj.put('k', 'v').then(() => {
+      return obj.get('k')
+    }).then((value) => {
+      assert(value === 'v')
+      done()
+    }).catch((err) => { console.error(err) })
+  })
+})


### PR DESCRIPTION
Changes multiledger and testPaymentExpiry so that ILP-Plugin-Virtual is able to be used in the connector. This includes adding a sqlite-based store in src/lib for persistence in ILP-Plugin-Virtual. ILP-Plugin-Virtual is also added as a dependency.