### PR TITLE
feature: send ledger precision and scale to quoter when getting quote

### DIFF
--- a/src/lib/info-cache.js
+++ b/src/lib/info-cache.js
@@ -30,8 +30,8 @@ class InfoCache {
       return cached
     }
 
-    const precision = yield this.getInfoUncached(ledger)
-    this.cache[ledger] = precision
+    const info = yield this.getInfoUncached(ledger)
+    this.cache[ledger] = info
     return this.cache[ledger]
   }
 

--- a/src/services/backend.js
+++ b/src/services/backend.js
@@ -2,6 +2,7 @@
 
 const config = require('./config')
 const Backend = require('../backends/' + config.get('backend'))
+const infoCache = require('./info-cache')
 
 if (!Backend) {
   throw new Error('Backend not found. The backend ' +
@@ -11,5 +12,6 @@ if (!Backend) {
 module.exports = new Backend({
   currencyWithLedgerPairs: config.get('tradingPairs'),
   backendUri: config.get('backendUri'),
-  spread: config.get('fxSpread')
+  spread: config.get('fxSpread'),
+  infoCache: infoCache
 })


### PR DESCRIPTION
feature: send ledger precision and scale to quoter when getting quote

The connector should send precision of the source or destination ledger
based on the quote value that needs to be computed (and rounded).

- If quote specifies source amount, then send the precision of the
  receiving ledger
- If quote specifies receive amount, then send the precision of the source ledger

