### PR TITLE
fix: handle fulfillment reject instead of returning string

### DIFF
--- a/src/lib/executeSourceTransfer.js
+++ b/src/lib/executeSourceTransfer.js
@@ -21,11 +21,11 @@ function * executeSourceTransfer (destinationTransfer, fulfillment, ledgers) {
   // TODO check the timestamp on the response from the ledger against
   // the transfer's expiry date
   // See https://github.com/interledger/five-bells-ledger/issues/149
-  const sourceTransferState = yield ledgers.getLedger(sourceTransferLedger)
+  yield ledgers.getLedger(sourceTransferLedger)
     .fulfillCondition(sourceTransferID, fulfillment)
-  if (sourceTransferState !== 'executed') {
-    log.error('Attempted to execute source transfer but it was unsucessful: we have not been fully repaid')
-  }
+    .catch(() => {
+      log.error('Attempted to execute source transfer but it was unsucessful: we have not been fully repaid')
+    })
 }
 
 module.exports = executeSourceTransfer

--- a/test/mocks/mockPlugin.js
+++ b/test/mocks/mockPlugin.js
@@ -31,6 +31,9 @@ class MockPlugin extends EventEmitter {
   }
 
   fulfillCondition (transferId, conditionFulfillment) {
+    if (conditionFulfillment === 'invalid') {
+      return Promise.reject(new Error('invalid fulfillment'))
+    }
     return Promise.resolve(null)
   }
 

--- a/test/paymentsSpec.js
+++ b/test/paymentsSpec.js
@@ -75,6 +75,17 @@ describe('Payments', function () {
     process.env = _.cloneDeep(env)
   })
 
+  it('should handle an invalid fulfillment', function * () {
+    this.mockPlugin1.emit('fulfill_execution_condition', {
+      id: '5857d460-2a46-4545-8311-1539d99e78e8',
+      direction: 'outgoing',
+      noteToSelf: {
+        source_transfer_id: '130394ed-f621-4663-80dc-910adc66f4c6',
+        source_transfer_ledger: 'http://test2.mock'
+      }
+    }, 'invalid') // 'invalid' triggers error in mock plugin
+  })
+
   it('should pass on an execution condition fulfillment', function * () {
     const fulfillSpy = sinon.spy(this.mockPlugin2, 'fulfillCondition')
     this.mockPlugin1.emit('fulfill_execution_condition', {


### PR DESCRIPTION
This code currently expects `fulfillCondition` to resolve to a string, although this is not specified in the LedgerPlugin interface. Instead, the connector should give an error on a rejected promise.