### PR TITLE
Feature flag for route shifting (on by default)

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -17,6 +17,7 @@ const DEFAULT_SLIPPAGE = 0.001 // 0.1%
 const DEFAULT_ROUTE_BROADCAST_INTERVAL = 30 * 1000 // milliseconds
 const DEFAULT_ROUTE_CLEANUP_INTERVAL = 1000 // milliseconds
 const DEFAULT_ROUTE_EXPIRY = 45 * 1000 // milliseconds
+const DEFAULT_ROUTE_SHIFT = true
 
 function isRunningTests () {
   return (
@@ -192,6 +193,8 @@ function getLocalConfig () {
     Number(Config.getEnv(envPrefix, 'ROUTE_CLEANUP_INTERVAL')) || DEFAULT_ROUTE_CLEANUP_INTERVAL
   const routeExpiry =
     Number(Config.getEnv(envPrefix, 'ROUTE_EXPIRY')) || DEFAULT_ROUTE_EXPIRY
+  const routeShift =
+    Config.castBool(Config.getEnv(envPrefix, 'ROUTE_SHIFT'), DEFAULT_ROUTE_SHIFT)
 
   // Credentials should be specified as a map of the form
   // {
@@ -230,7 +233,8 @@ function getLocalConfig () {
     notifications,
     routeBroadcastInterval,
     routeCleanupInterval,
-    routeExpiry
+    routeExpiry,
+    routeShift
   }
 }
 

--- a/src/lib/route-broadcaster.js
+++ b/src/lib/route-broadcaster.js
@@ -34,6 +34,7 @@ class RouteBroadcaster {
     this.tradingPairs = config.tradingPairs
     this.minMessageWindow = config.minMessageWindow
     this.adjacentConnectors = {}
+    this.routeShift = config.routeShift
   }
 
   * start () {
@@ -114,7 +115,7 @@ class RouteBroadcaster {
       destination_ledger: destinationLedger,
       source_amount: 100000000
     }).then((quote) => this._quoteToLocalRoute(quote))
-      .then((route) => co(this._shiftRoute.bind(this), route))
+      .then((route) => this.routeShift ? co(this._shiftRoute.bind(this), route) : route)
   }
 
   _quoteToLocalRoute (quote) {

--- a/src/services/route-broadcaster.js
+++ b/src/services/route-broadcaster.js
@@ -11,5 +11,6 @@ module.exports = new RouteBroadcaster(
     tradingPairs: config.tradingPairs,
     minMessageWindow: config.expiry.minMessageWindow,
     routeCleanupInterval: config.routeCleanupInterval,
-    routeBroadcastInterval: config.routeBroadcastInterval
+    routeBroadcastInterval: config.routeBroadcastInterval,
+    routeShift: config.routeShift
   })

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -42,7 +42,8 @@ exports.create = function (context) {
     tradingPairs: config.tradingPairs,
     minMessageWindow: config.expiry.minMessageWindow,
     routeCleanupInterval: config.routeCleanupInterval,
-    routeBroadcastInterval: config.routeBroadcastInterval
+    routeBroadcastInterval: config.routeBroadcastInterval,
+    routeShift: config.routeShift
   })
   const balanceCache = new BalanceCache(ledgers)
   const app = createApp(config, ledgers, backend, routeBuilder, routeBroadcaster, routingTables, infoCache, balanceCache)


### PR DESCRIPTION
Feature flag for curve shifting. Some clients do not (yet) work with that feature. This flag allows to disable it until this is fixed. Should not impact other use cases since the feature is on by default.