### PR TITLE
feat: BREAKING pass through ILP packet

### DIFF
--- a/src/lib/route-builder.js
+++ b/src/lib/route-builder.js
@@ -143,7 +143,7 @@ class RouteBuilder {
       direction: 'outgoing',
       account: nextHop.destinationCreditAccount,
       amount: nextHop.destinationAmount,
-      data: nextHop.isFinal ? ilpHeader.data : { ilp_header: ilpHeader },
+      data: { ilp_header: ilpHeader },
       noteToSelf,
       executionCondition: sourceTransfer.executionCondition,
       cancellationCondition: sourceTransfer.cancellationCondition,

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -167,6 +167,13 @@ describe('RouteBuilder', function () {
         noteToSelf: {
           source_transfer_id: 'fd7ecefd-8eb8-4e16-b7c8-b67d9d6995f5',
           source_transfer_ledger: ledgerA
+        },
+        data: {
+          ilp_header: {
+            ledger: ledgerB,
+            account: bobB,
+            amount: '50'
+          }
         }
       })
     })
@@ -195,6 +202,37 @@ describe('RouteBuilder', function () {
         noteToSelf: {
           source_transfer_id: 'ce83ac53-3abb-47d3-b32d-37aa36dd6372',
           source_transfer_ledger: ledgerA
+        },
+        data: {
+          ilp_header: {
+            ledger: ledgerB,
+            account: bobB,
+            amount: '50'
+          }
+        }
+      })
+    })
+
+    it('passes on the ilp_header', function * () {
+      const destinationTransfer = yield this.builder.getDestinationTransfer({
+        id: 'fd7ecefd-8eb8-4e16-b7c8-b67d9d6995f5',
+        ledger: ledgerA,
+        direction: 'incoming',
+        account: aliceA,
+        amount: '100',
+        data: {
+          ilp_header: {
+            ledger: ledgerB,
+            account: bobB,
+            amount: '50'
+          }
+        }
+      })
+      assert.deepEqual(destinationTransfer.data, {
+        ilp_header: {
+          ledger: ledgerB,
+          account: bobB,
+          amount: '50'
         }
       })
     })


### PR DESCRIPTION
the connector was stripping the ilp header before sending the last
transfer. the full ilp packet is useful for the recipient to check the
details of the incoming transfer against what was supposed to happen
(i.e. what was in the packet).

this changes the behavior to pass
through the whole ILP packet. this is also useful for when we switch to
binary, as it is arguably simpler for the connector to just forward on
the packet rather than stripping particular fields before sending it to
the receiver. if we do want to strip fields before handing the packet
off to the actual end user, the client libraries can do that.

requires https://github.com/interledger/five-bells-receiver/pull/4 for integration tests to pass.