### PR TITLE
fix: make quoting less pessimistic

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -16,7 +16,6 @@ const DEFAULT_SLIPPAGE = 0.001 // 0.1%
 const DEFAULT_ROUTE_BROADCAST_INTERVAL = 30 * 1000 // milliseconds
 const DEFAULT_ROUTE_CLEANUP_INTERVAL = 1000 // milliseconds
 const DEFAULT_ROUTE_EXPIRY = 45 * 1000 // milliseconds
-const DEFAULT_ROUTE_SHIFT = true
 
 function isRunningTests () {
   return (
@@ -201,8 +200,6 @@ function getLocalConfig () {
     Number(Config.getEnv(envPrefix, 'ROUTE_CLEANUP_INTERVAL')) || DEFAULT_ROUTE_CLEANUP_INTERVAL
   const routeExpiry =
     Number(Config.getEnv(envPrefix, 'ROUTE_EXPIRY')) || DEFAULT_ROUTE_EXPIRY
-  const routeShift =
-    Config.castBool(Config.getEnv(envPrefix, 'ROUTE_SHIFT'), DEFAULT_ROUTE_SHIFT)
 
   // Credentials should be specified as a map of the form
   // {
@@ -243,7 +240,6 @@ function getLocalConfig () {
     routeBroadcastInterval,
     routeCleanupInterval,
     routeExpiry,
-    routeShift,
     logLevel
   }
 }

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -2,18 +2,32 @@
 const routing = require('five-bells-routing')
 
 /**
- * Maintain two sets of `routing.RoutingTables`.
+ * When routing payments across multiple ledgers, each hop will round the amounts
+ * according to the precision of the ledger. These rounding errors can accumulate
+ * to the point where a connector later in a path may receive an amount that is
+ * less than the rate they are willing to accept.
  *
- * The "local" tables consist of the raw local routes, joined to the
- * remote (shifted) routes.
+ * Connectors broadcast slightly pessimistic rate curves in order to compensate for
+ * rounding errors across multi-hop routes. They shift the curve by the maximum
+ * amount that could be lost due to rounding errors, so that even if the incoming
+ * amount is rounded down by that amount the resulting value will still match the
+ * connector's minimum rate.
  *
- * The "public" tables consist of the local shifted routes, joined to the
- * remote (shifted) routes.
- * Before joining, the local routes are shifted down by 1/10^destination_ledger_scale
- * to pessimistically account for rounding errors.
+ * Connectors use unshifted rate curves locally to determine whether an incoming
+ * payment request matches their minimum rate. When applying this rate, they round
+ * in their favor to ensure that they never accept a payment that is lower than their rate.
  *
- * The "local" tables are used for `findBestHopFor*`.
- * The "public" tables are broadcast to adjacent connectors.
+ * This class maintains two sets of routing.RoutingTables: the "local" tables are
+ * the optimistic ones and the "public" tables are the pessimistic ones.
+ *
+ * The "local" tables consist of the raw local routes, joined to adjacent connector's
+ * (public, shifted) routes. They are used for findBestHopFor*, the results of which
+ * must be rounded in the connector's own favor to ensure that they don't lose money.
+ *
+ * The "public" tables consist of the local shifted routes, joined to the remote
+ * (shifted) routes. Before joining, the local routes are shifted down by
+ * 1/10^destination_ledger_scale to account for rounding errors. Their curves are
+ * broadcast to adjacent connectors.
  */
 class RoutingTables {
   constructor (baseURI, expiryDuration) {

--- a/src/lib/routing-tables.js
+++ b/src/lib/routing-tables.js
@@ -1,0 +1,70 @@
+'use strict'
+const routing = require('five-bells-routing')
+
+/**
+ * Maintain two sets of `routing.RoutingTables`.
+ *
+ * The "local" tables consist of the raw local routes, joined to the
+ * remote (shifted) routes.
+ *
+ * The "public" tables consist of the local shifted routes, joined to the
+ * remote (shifted) routes.
+ * Before joining, the local routes are shifted down by 1/10^destination_ledger_scale
+ * to pessimistically account for rounding errors.
+ *
+ * The "local" tables are used for `findBestHopFor*`.
+ * The "public" tables are broadcast to adjacent connectors.
+ */
+class RoutingTables {
+  constructor (baseURI, expiryDuration) {
+    this.baseURI = baseURI
+    this.localTables = new routing.RoutingTables(baseURI, [], expiryDuration)
+    this.publicTables = new routing.RoutingTables(baseURI, [], expiryDuration)
+  }
+
+  * addLocalRoutes (infoCache, _localRoutes) {
+    const localRoutes = _localRoutes.map(routing.Route.fromData)
+    this.localTables.addLocalRoutes(localRoutes)
+
+    // Shift the graph down by a small amount so that precision rounding doesn't
+    // cause UnacceptableRateErrors.
+    for (const localRoute of localRoutes) {
+      const destinationAdjustment =
+        yield this._getScaleAdjustment(infoCache, localRoute.destinationLedger)
+      this.publicTables.addLocalRoutes([
+        localRoute.shiftY(-destinationAdjustment)
+      ])
+    }
+  }
+
+  addRoute (route) {
+    this.localTables.addRoute(route)
+    return this.publicTables.addRoute(route)
+  }
+
+  findBestHopForSourceAmount (sourceLedger, destinationLedger, sourceAmount) {
+    return this.localTables.findBestHopForSourceAmount(
+      sourceLedger, destinationLedger, sourceAmount)
+  }
+
+  findBestHopForDestinationAmount (sourceLedger, destinationLedger, destinationAmount) {
+    return this.localTables.findBestHopForDestinationAmount(
+      sourceLedger, destinationLedger, destinationAmount)
+  }
+
+  toJSON (maxPoints) {
+    return this.publicTables.toJSON(maxPoints)
+  }
+
+  removeExpiredRoutes () {
+    this.localTables.removeExpiredRoutes()
+    this.publicTables.removeExpiredRoutes()
+  }
+
+  * _getScaleAdjustment (infoCache, ledger) {
+    const scale = (yield infoCache.get(ledger)).scale
+    return scale ? Math.pow(10, -scale) : 0
+  }
+}
+
+module.exports = RoutingTables

--- a/src/services/route-broadcaster.js
+++ b/src/services/route-broadcaster.js
@@ -11,6 +11,5 @@ module.exports = new RouteBroadcaster(
     tradingPairs: config.tradingPairs,
     minMessageWindow: config.expiry.minMessageWindow,
     routeCleanupInterval: config.routeCleanupInterval,
-    routeBroadcastInterval: config.routeBroadcastInterval,
-    routeShift: config.routeShift
+    routeBroadcastInterval: config.routeBroadcastInterval
   })

--- a/src/services/routing-tables.js
+++ b/src/services/routing-tables.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const RoutingTables = require('five-bells-routing').RoutingTables
+const RoutingTables = require('../lib/routing-tables')
 const config = require('./config')
 
-module.exports = new RoutingTables(config.server.base_uri, [], config.routeExpiry)
+module.exports = new RoutingTables(
+  config.server.base_uri,
+  config.routeExpiry)

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -7,7 +7,7 @@ const log = require('../../src/common').log
 
 const loadConfig = require('../../src/lib/config')
 const InfoCache = require('../../src/lib/info-cache')
-const RoutingTables = require('five-bells-routing').RoutingTables
+const RoutingTables = require('../../src/lib/routing-tables')
 const RouteBuilder = require('../../src/lib/route-builder')
 const RouteBroadcaster = require('../../src/lib/route-broadcaster')
 const makeCore = require('../../src/lib/core')
@@ -23,7 +23,7 @@ exports.create = function (context) {
     backendUri: config.get('backendUri'),
     spread: config.get('fxSpread')
   })
-  const routingTables = new RoutingTables(config.server.base_uri, [], config.routeExpiry)
+  const routingTables = new RoutingTables(config.server.base_uri, config.routeExpiry)
   const core = makeCore({config, log, routingTables})
   const infoCache = new InfoCache(core)
   const routeBuilder = new RouteBuilder(
@@ -39,8 +39,7 @@ exports.create = function (context) {
     tradingPairs: config.tradingPairs,
     minMessageWindow: config.expiry.minMessageWindow,
     routeCleanupInterval: config.routeCleanupInterval,
-    routeBroadcastInterval: config.routeBroadcastInterval,
-    routeShift: config.routeShift
+    routeBroadcastInterval: config.routeBroadcastInterval
   })
   const balanceCache = new BalanceCache(core)
   const app = createApp(config, core, backend, routeBuilder, routeBroadcaster, routingTables, infoCache, balanceCache)

--- a/test/quoteSpec.js
+++ b/test/quoteSpec.js
@@ -377,7 +377,7 @@ describe('Quotes', function () {
           source_amount: '100.00',
           source_expiry_duration: '6',
           destination_ledger: 'usd-ledger.',
-          destination_amount: '105.6023', // EUR/USD Rate of 1.0592 - .2% spread - slippage
+          destination_amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
           destination_expiry_duration: '5'
         })
         .end()
@@ -458,7 +458,7 @@ describe('Quotes', function () {
           source_amount: '100.0000',
           source_expiry_duration: '6',
           destination_ledger: 'usd-ledger.',
-          destination_amount: '105.6023', // EUR/USD Rate of 1.0592 - .2% spread - slippage
+          destination_amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
           destination_expiry_duration: '5'
         })
         .end()
@@ -474,7 +474,7 @@ describe('Quotes', function () {
         .expect(200, {
           source_connector_account: 'mocky',
           source_ledger: 'eur-ledger.',
-          source_amount: '94.6948', // (1/ EUR/USD Rate of 1.0592) + .2% spread + round up to overestimate + slippage
+          source_amount: '94.6947', // (1/ EUR/USD Rate of 1.0592) + .2% spread + round up to overestimate + slippage
           source_expiry_duration: '6',
           destination_ledger: 'usd-ledger.',
           destination_amount: '100.0000',
@@ -494,7 +494,7 @@ describe('Quotes', function () {
           source_amount: '100.0000',
           source_expiry_duration: '6',
           destination_ledger: 'usd-ledger.',
-          destination_amount: '105.6023', // EUR/USD Rate of 1.0592 - .2% spread - slippage
+          destination_amount: '105.6024', // EUR/USD Rate of 1.0592 - .2% spread - slippage
           destination_expiry_duration: '5'
         })
         .end()
@@ -511,7 +511,7 @@ describe('Quotes', function () {
           source_amount: '100.0000',
           source_expiry_duration: '6',
           destination_ledger: 'eur-ledger.',
-          destination_amount: '94.1277', // 1 / (EUR/USD Rate of 1.0592 + .2% spread) - slippage
+          destination_amount: '94.1278', // 1 / (EUR/USD Rate of 1.0592 + .2% spread) - slippage
           destination_expiry_duration: '5'
         })
         .end()
@@ -528,7 +528,7 @@ describe('Quotes', function () {
           source_amount: '100.0000',
           source_expiry_duration: '6',
           destination_ledger: 'cad-ledger.',
-          destination_amount: '127.8537', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread - slippage
+          destination_amount: '127.8538', // USD/CAD Rate (1.3583 / 1.0592) - .2% spread - slippage
           destination_expiry_duration: '5'
         })
         .end()
@@ -545,7 +545,7 @@ describe('Quotes', function () {
           source_amount: '100.0000',
           source_expiry_duration: '6',
           destination_ledger: 'usd-ledger.',
-          destination_amount: '77.7459', // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread) - slippage
+          destination_amount: '77.7460', // 1/(USD/CAD Rate (1.3583 / 1.0592) + .2% spread) - slippage
           destination_expiry_duration: '5'
         })
         .end()
@@ -661,7 +661,7 @@ describe('Quotes', function () {
             source_amount: '100.0000',
             source_expiry_duration: '7',
             destination_ledger: 'random-ledger.',
-            destination_amount: '188.2554',
+            destination_amount: '188.2556',
             destination_expiry_duration: '5'
           })
         })

--- a/test/routeBroadcasterSpec.js
+++ b/test/routeBroadcasterSpec.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const routing = require('five-bells-routing')
+const RoutingTables = require('../src/lib/routing-tables')
 const RouteBroadcaster = require('five-bells-connector')._test.RouteBroadcaster
 const nock = require('nock')
 const appHelper = require('./helpers/app')
@@ -16,7 +17,14 @@ describe('RouteBroadcaster', function () {
   beforeEach(function * () {
     appHelper.create(this)
 
-    this.tables = new routing.RoutingTables(baseURI, [{
+    this.infoCache = {
+      get: function * (ledger) {
+        return {precision: 10, scale: 2}
+      }
+    }
+
+    this.tables = new RoutingTables(baseURI)
+    yield this.tables.addLocalRoutes(this.infoCache, [{
       source_ledger: ledgerA,
       destination_ledger: ledgerB,
       connector: baseURI,
@@ -35,12 +43,6 @@ describe('RouteBroadcaster', function () {
       points: [ [0, 0], [100, 200] ],
       additional_info: {}
     }])
-
-    this.infoCache = {
-      get: function * (ledger) {
-        return {precision: 10, scale: 2}
-      }
-    }
 
     this.broadcaster = new RouteBroadcaster(this.tables, this.backend, this.core, this.infoCache, {
       tradingPairs: [
@@ -78,21 +80,21 @@ describe('RouteBroadcaster', function () {
           connector: 'http://connector.example',
           min_message_window: 1,
           source_account: ledgerA + '.mark',
-          points: [ [0, 0], [200, 100] ]
+          points: [ [0, -0.01], [200, 99.99] ]
         }, {
           source_ledger: ledgerA,
           destination_ledger: ledgerC,
           connector: 'http://connector.example',
           min_message_window: 2,
           source_account: ledgerA + '.mark',
-          points: [ [0, 0], [100, 60], [200, 60] ]
+          points: [ [0, 0], [0.02, 0], [100.02, 60], [200, 60] ]
         }, {
           source_ledger: ledgerB,
           destination_ledger: ledgerA,
           connector: 'http://connector.example',
           min_message_window: 1,
           source_account: ledgerB + '.mark',
-          points: [ [0, 0], [100, 200] ]
+          points: [ [0, -0.01], [100, 199.99] ]
         }
       ]).reply(200)
 

--- a/test/routeBuilderSpec.js
+++ b/test/routeBuilderSpec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const assert = require('assert')
-const RoutingTables = require('five-bells-routing').RoutingTables
+const RoutingTables = require('../src/lib/routing-tables')
 const RouteBuilder = require('five-bells-connector')._test.RouteBuilder
 const appHelper = require('./helpers/app')
 const logHelper = require('./helpers/log')
@@ -36,7 +36,8 @@ describe('RouteBuilder', function () {
     this.core.getPlugin(ledgerA).getAccount = function () { return markA }
     this.core.getPlugin(ledgerB).getAccount = function () { return markB }
 
-    this.tables = new RoutingTables(baseURI, [{
+    this.tables = new RoutingTables(baseURI)
+    yield this.tables.addLocalRoutes(this.infoCache, [{
       source_ledger: ledgerA,
       destination_ledger: ledgerB,
       connector: 'http://mark.example',


### PR DESCRIPTION
Tests will pass once https://github.com/interledger/five-bells-integration-test/pull/27 is merged.

This change makes quoting less pessimistic by using unshifted local routes for `findBestHopBy*`, (but still broadcasting the shifted routes) and always rounding in the connector's favor.