### PR TITLE
feat: add a backend using coinmarketcap

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "five-bells-shared": "^18.1.0",
     "ilp-core": "~7.0.1",
     "ilp-plugin-bells": "^5.0.0",
-    "ilp-plugin-virtual": "^4.0.1",
+    "ilp-plugin-virtual": "^4.3.0",
     "koa": "^1.0.0",
     "koa-bunyan-logger": "^1.3.0",
     "koa-compress": "^1.0.6",

--- a/src/backends/fixerio-plus-coinmarketcap.js
+++ b/src/backends/fixerio-plus-coinmarketcap.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const request = require('co-request')
+const FixerIoBackend = require('./fixerio')
+const COINMARKETCAP_API = 'https://api.coinmarketcap.com/v1/ticker/'
+const fromPairs = require('lodash/fromPairs')
+const ROUNDING_FACTOR = 100000000
+
+class FixerIoCoinMarketCapBackend extends FixerIoBackend {
+  * connect (mockData) {
+    yield super.connect(mockData)
+    const ccRates = yield this._getCCRates(this.rates.USD)
+    Object.assign(this.rates, ccRates)
+    this.currencies = this.currencies.concat(Object.keys(ccRates))
+    this.currencies.sort()
+  }
+
+  * _getCCRates (usdRate) {
+    let rateRes = yield request({
+      method: 'get',
+      uri: COINMARKETCAP_API,
+      json: true
+    })
+    if (rateRes.statusCode !== 200) {
+      throw new Error('Unexpected status from coinmarketcap.com: ' + rateRes.statusCode)
+    }
+    return fromPairs(rateRes.body.map((rateInfo) => {
+      return [rateInfo.symbol, Math.floor(ROUNDING_FACTOR / (rateInfo.price_usd * usdRate)) / ROUNDING_FACTOR]
+    }))
+  }
+}
+
+module.exports = FixerIoCoinMarketCapBackend


### PR DESCRIPTION
Load exchange rate data from Coinmarketcap (and combine with Fixer.io) to support cryptocurrencies and fiat currencies alike.