### PR TITLE
refactor(middleware): move middleware composition code to pipeline class

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,5 @@
 import { createHash, randomBytes, createHmac } from 'crypto'
 import { resolve } from 'path'
-import { MiddlewareMethod } from '../types/middleware'
 
 export const sha256 = (preimage: Buffer) => {
   return createHash('sha256').update(preimage).digest()
@@ -59,26 +58,6 @@ export const extractDefaultsFromSchema = (schema: any, path = '') => {
       return result
     default:
       throw new Error('No default found for schema path: ' + path)
-  }
-}
-
-export function composeMiddleware<T, U> (
-  middleware: MiddlewareMethod<T, U>[]
-): MiddlewareMethod<T, U> {
-  return function (val: T, next: MiddlewareMethod<T, U>) {
-    // last called middleware #
-    let index = -1
-    return dispatch(0, val)
-    async function dispatch (i: number, val: T): Promise<U> {
-      if (i <= index) {
-        throw new Error('next() called multiple times.')
-      }
-      index = i
-      const fn = (i === middleware.length) ? next : middleware[i]
-      return fn(val, function next (val: T) {
-        return dispatch(i + 1, val)
-      })
-    }
   }
 }
 

--- a/src/services/middleware-manager.ts
+++ b/src/services/middleware-manager.ts
@@ -1,6 +1,6 @@
 import reduct = require('reduct')
 
-import { loadModuleOfType, composeMiddleware } from '../lib/utils'
+import { loadModuleOfType } from '../lib/utils'
 import { create as createLogger } from '../common/log'
 const log = createLogger('middleware-manager')
 
@@ -121,6 +121,7 @@ export default class MiddlewareManager {
    * This should be called after the plugins are connected
    */
   async startup () {
+    log.debug('running startup middleware.')
     for (const handler of this.startupHandlers.values()) {
       await handler(undefined)
     }
@@ -219,7 +220,7 @@ export default class MiddlewareManager {
   }
 
   private createHandler<T,U> (pipeline: Pipeline<T,U>, accountId: string, next: (param: T) => Promise<U>): (param: T) => Promise<U> {
-    const middleware: MiddlewareMethod<T,U> = composeMiddleware(pipeline.getMethods())
+    const middleware: MiddlewareMethod<T,U> = pipeline.compose()
 
     return (param: T) => middleware(param, next)
   }

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -44,7 +44,7 @@ export interface Pipeline<T,U> {
   insertLast (entry: PipelineEntry<T,U>): void
   insertBefore (middlewareName: string, entry: PipelineEntry<T,U>): void
   insertAfter (middlewareName: string, entry: PipelineEntry<T,U>): void
-  getMethods (): MiddlewareMethod<T,U>[]
+  compose (): MiddlewareMethod<T,U>
 }
 
 export interface Pipelines {


### PR DESCRIPTION
Composing middleware is really only done by middleware pipelines, so it should be part of the `MiddlewarePipeline` class, not in `utils.ts`.